### PR TITLE
[ansible] Allow SSL verification to SortingHat Nginx

### DIFF
--- a/ansible/roles/sortinghat/defaults/main.yml
+++ b/ansible/roles/sortinghat/defaults/main.yml
@@ -46,12 +46,14 @@ nginx_docker_container: nginx
 nginx_workdir: "/docker/nginx"
 nginx_virtualhosts_workdir: "{{ nginx_workdir }}/conf"
 
-## Certificates configuration
+## Enable SSL
+enable_ssl: False
 
+## Certificates configuration. Only used if SSL is enabled
 certs_dir: "{{ nginx_workdir }}/certs"
 
 ## Uncomment to define custom certificates. Otherwise self-signed
-## certificates will be used.
+## certificates will be used. Only needed if SSL is enabled
 # custom_cert:
 #   cert: foo/cert.crt
 #   key: foo/cert.key

--- a/ansible/roles/sortinghat/tasks/nginx.yml
+++ b/ansible/roles/sortinghat/tasks/nginx.yml
@@ -6,7 +6,7 @@
     name: "{{ nginx_docker_container }}"
     state: absent
 
-- name: Start NGINX container
+- name: Start NGINX container without SSL
   docker_container:
     name: "{{ nginx_docker_container }}"
     image: "{{ nginx_docker_image }}:{{ nginx_version }}"
@@ -16,4 +16,20 @@
       - "80:80"    
     exposed_ports:
       - "80"
-     
+  when: enable_ssl|bool == false
+
+- name: Start NGINX container enabling SSL
+  docker_container:
+    name: "{{ nginx_docker_container }}"
+    image: "{{ nginx_docker_image }}:{{ nginx_version }}"
+    volumes:
+      - "{{ nginx_virtualhosts_workdir}}:/etc/nginx/conf.d/"
+      - "{{ certs_dir }}/{{ ansible_hostname }}.crt:/etc/ssl/certs/{{ ansible_hostname }}.crt"
+      - "{{ certs_dir }}/{{ ansible_hostname }}.key:/etc/ssl/private/{{ ansible_hostname }}.key"
+    ports:
+      - "80:80"
+      - "443:443"
+    exposed_ports:
+      - "80"
+      - "443"
+  when: enable_ssl|bool == true

--- a/ansible/roles/sortinghat/tasks/virtualhost.yml
+++ b/ansible/roles/sortinghat/tasks/virtualhost.yml
@@ -7,6 +7,45 @@
     mode: 0750
     recurse: true
 
+- name: Create certificates directory
+  file:
+    path: "{{ certs_dir }}"
+    state: directory
+    mode: 0750
+    recurse: true
+  when: enable_ssl|bool == true
+
+- name: "Generate self-signed certificate for {{ ansible_hostname }}"
+  shell: "./generate_cert.sh {{ ansible_hostname }}"
+  become: false
+  args:
+    chdir: "{{ role_path }}/files"
+    creates: "{{ role_path }}/files/cert.crt"
+  delegate_to: localhost
+  when: (enable_ssl|bool == true) and (custom_cert is not defined)
+
+- name: "Copy SSL certificate for {{ ansible_hostname }}"
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - src: "{{ custom_cert.cert if custom_cert is defined else 'cert.crt' }}"
+      dest: "{{ certs_dir }}/{{ ansible_hostname }}.crt"
+      owner: '1000'
+      group: '1000'
+      mode: '0644'
+    - src: "{{ custom_cert.key if custom_cert is defined else 'cert.key' }}"
+      dest: "{{ certs_dir }}/{{ ansible_hostname }}.key"
+      owner: '1000'
+      group: '1000'
+      mode: '0600'
+  loop_control:
+    label: "{{ item.dest }}"
+  when: (enable_ssl|bool == true) and (certs_dir is defined)
+
 - name: "Create virtualhost configuration for {{ ansible_hostname }}"
   template:
     src: "{{ item.template }}"

--- a/ansible/roles/sortinghat/templates/vhost.j2
+++ b/ansible/roles/sortinghat/templates/vhost.j2
@@ -1,16 +1,47 @@
 upstream sortinghat {
     server {{ sortinghat_host }};
 }
-
+{% if enable_ssl | bool %}
 server {
     listen 80;
     server_name {{ ansible_hostname }};
+
+    return 301 https://{{ ansible_hostname }};
+}
+{% endif %}
+
+server {
+    server_name {{ ansible_hostname }};
+
     include    mime.types;
     sendfile   on;
 
+{% if enable_ssl | bool %}
+    listen 443 ssl http2;
+
+    ssl on;
+
+    ssl_certificate /etc/ssl/certs/{{ ansible_hostname }}.crt;
+    ssl_certificate_key /etc/ssl/private/{{ ansible_hostname }}.key;
+
+    ssl_protocols TLSv1.3 TLSv1.2;
+    ssl_ciphers AES256+EECDH:AES256+EDH:!aNULL;
+    ssl_prefer_server_ciphers on;
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    add_header Strict-Transport-Security "max-age=63072000;" always;
+{% else %}
+    listen 80;
+{% endif %}
+
     location /identities/api/ {
         rewrite ^/identities/(.*) /$1 break;
+
         include /etc/nginx/conf.d/{{ ansible_hostname }}_uwsgi_params;
+
         uwsgi_pass sortinghat;
         uwsgi_param Host $host;
         uwsgi_param X-Real-IP $remote_addr;


### PR DESCRIPTION
This commit allows SortingHat Nginx to enable SSL verification as optional.

Signed-off-by: Quan Zhou <quan@bitergia.com>