### PR TITLE
[ansible] Upgrade GrimoireLab to 0.8.0

### DIFF
--- a/ansible/roles/mordred/defaults/main.yml
+++ b/ansible/roles/mordred/defaults/main.yml
@@ -2,7 +2,7 @@
 
 # GrimoireLab image and container
 grimoirelab_docker_image: grimoirelab/grimoirelab
-grimoirelab_version: 0.7.2-rc.1
+grimoirelab_version: 0.8.0
 
 # GrimoireLab configuration
 mordred_workdir: "/docker/mordred"


### PR DESCRIPTION
This commit updates the GrimoireLab version to 0.8.0.

Signed-off-by: Daniel Rodríguez <drodr@bitergia.com>