### PR TITLE
[ansible] Add wildcard to database when granting privileges

### DIFF
--- a/ansible/roles/sortinghat/tasks/main.yml
+++ b/ansible/roles/sortinghat/tasks/main.yml
@@ -5,7 +5,7 @@
     name: "{{ mariadb_service_account }}"
     host: "{{ ansible_default_ipv4.address }}"
     password: "{{ mariadb_service_account_password }}"
-    priv: "{{ sortinghat_database }}.*:ALL,GRANT"
+    priv: "{{ sortinghat_database }}%.*:ALL,GRANT"
     login_user: root
     login_password: "{{ mariadb_root_password }}"
     login_host: "{{ item }}"


### PR DESCRIPTION
This commit adds a wildcard to the database when the SortingHat role creates a MariaDB service account that grants privileges.

This is needed when SortingHat has to migrate from an old database `0.7.x` to `0.8.x` or higher, as it creates a backup database `<database-name>_backup`.