### PR TITLE
[ansible] Fix OpenSearch hostname in Mordred role

### DIFF
--- a/ansible/roles/mordred/tasks/configure_instance.yml
+++ b/ansible/roles/mordred/tasks/configure_instance.yml
@@ -75,12 +75,12 @@
   become: false
   command: >-
     python3 {{ role_path }}/files/create_roles_tenant.py
-    https://{{ opensearch_admin_user }}:{{ opensearch_admin_password }}@opensearch-0:9200 {{ instance.tenant }}
+    https://{{ opensearch_admin_user }}:{{ opensearch_admin_password }}@{{ groups['opensearch'][0] }}:9200 {{ instance.tenant }}
   delegate_to: localhost
 
 - name: "Create mordred user for {{ instance.project }}"
   uri:
-    url: "https://opensearch-0:9200/_plugins/_security/api/internalusers/{{ instance.tenant }}_mordred"
+    url: "https://{{ groups['opensearch'][0] }}:9200/_plugins/_security/api/internalusers/{{ instance.tenant }}_mordred"
     url_username: "{{ opensearch_admin_user }}"
     url_password: "{{ opensearch_admin_password }}"
     method: PUT


### PR DESCRIPTION
This commit fixes OpenSearch hostname in the Mordred role. Since
instances use prefixes in their names, `opensearch-0` is not
longer valid. Instead of that it uses the first hostname of the
`opensearch` group.