### PR TITLE
Nginx serve SortingHat static files locally

### DIFF
--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -11,6 +11,7 @@
       - python3-setuptools
       - python3-pip
     state: present
+    update_cache: true
   tags: packages
 
 - name: Install and configure Docker
@@ -20,3 +21,4 @@
 - name: Install Python packages
   pip:
     name: "{{ python_packages }}"
+

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -31,9 +31,19 @@ certs_dir: "{{ nginx_workdir }}/certs"
 #   cert: foo/cert.crt
 #   key: foo/cert.key
 
-
 # NGINX proxy buffer settings
 nginx_proxy_buffer_size: "128k"
 nginx_proxy_buffer_size_per_conn: "256k"
 nginx_proxy_total_buffers: 4
 nginx_proxy_busy_buffers_size: "256k"
+
+# GCS bucket access
+## GCS directories
+nginx_gcs_workdir: /docker/nginx/gcs
+nginx_keys_workdir: /docker/nginx/keys
+
+## Gcloud repository
+gcloud_apt_deb_ubuntu_repository: >-
+  deb [signed-by=/usr/share/keyrings/cloud.google.gpg]
+  https://packages.cloud.google.com/apt cloud-sdk main
+

--- a/ansible/roles/nginx/tasks/gcs.yml
+++ b/ansible/roles/nginx/tasks/gcs.yml
@@ -1,0 +1,40 @@
+---
+
+- name: Add GPG key for gcloud repository
+  shell: "curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -"
+
+- name: Add gcloud repository (Debian/Ubuntu)
+  apt_repository:
+    repo: "{{ gcloud_apt_deb_ubuntu_repository }}"
+    state: present
+    update_cache: true
+  when: ansible_distribution == "Debian"
+    or ansible_distribution == "Ubuntu"
+
+- name: Install gcloud package
+  apt:
+    name: google-cloud-cli
+    state: present
+    update_cache: true
+
+- name: Create GCS folders
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0755
+    recurse: true
+  with_items:
+    - "{{ nginx_gcs_workdir }}"
+    - "{{ nginx_keys_workdir }}"
+
+- name: Copy GCP service account file
+  copy:
+    src: "{{ gcp_service_account_host_file }}"
+    dest: "{{ nginx_keys_workdir }}/key.json"
+    owner: '1000'
+    group: '1000'
+    mode: 0644
+
+- name: Activate service account
+  shell: gcloud auth activate-service-account --key-file "{{ nginx_keys_workdir }}/key.json"
+

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -6,6 +6,9 @@
   loop_control:
     loop_var: instance
 
+- name: Configure Google Cloud Storage (GCS)
+  include_tasks: gcs.yml
+
 - name: Configure NGINX proxy buffer sizes
   template:
     src: proxy_buffer.conf.j2
@@ -19,27 +22,31 @@
 
 - name: Create docker volumes for certs and config
   set_fact:
-    volumes_certs: |-
+    nginx_volumes: |-
       [
       {% for instance in nginx_virtualhosts %}
         "{{ certs_dir }}/{{ instance.fqdn }}.crt:/etc/ssl/certs/{{ instance.fqdn }}.crt",
         "{{ certs_dir }}/{{ instance.fqdn }}.key:/etc/ssl/private/{{ instance.fqdn }}.key",
       {% endfor %}
-        "{{ nginx_virtualhosts_workdir}}:/etc/nginx/conf.d/"
+        "{{ nginx_virtualhosts_workdir}}:/etc/nginx/conf.d/",
+        "{{ nginx_gcs_workdir }}:/opt/gcs"
       ]
 
 - name: Check the list of volumes
   debug:
-    msg: "{{ volumes_certs }}"
+    msg: "{{ nginx_volumes }}"
 
 - name: Start NGINX container
   docker_container:
     name: "{{ nginx_docker_container }}"
     image: "{{ nginx_docker_image }}:{{ nginx_version }}"
-    volumes: "{{ volumes_certs }}"
+    volumes: "{{ nginx_volumes }}"
     ports:
       - "80:80"
       - "443:443"
     exposed_ports:
       - "80"
       - "443"
+
+- name: Launch first rsync
+  shell: gsutil -m rsync -d -r "gs://{{ sortinghat_assets_bucket }}/" "{{ nginx_gcs_workdir }}"

--- a/ansible/roles/nginx/templates/vhost.j2
+++ b/ansible/roles/nginx/templates/vhost.j2
@@ -47,7 +47,7 @@ server {
     }
 
     location /identities {
-        rewrite                 ^/identities/(.*) /$1 break;
+        rewrite ^/identities/(.*) /$1 break;
 
         include /etc/nginx/conf.d/{{ instance.fqdn }}_uwsgi_params;
         uwsgi_pass {{ sortinghat_host }};
@@ -57,35 +57,14 @@ server {
         uwsgi_param X-Forwarded-Proto $http_x_forwarded_proto;
     }
 
+    location ~ ^/identities/favicon-grimoirelab.ico {
+      rewrite ^/identities/(.*)$ /$1 break;
+      root /opt/gcs/;
+    }
+
     location ~ ^/identities/(css|js|fonts)/ {
-        resolver                8.8.8.8 valid=300s ipv6=off;
-        resolver_timeout        10s;
-
-        rewrite                 ^/identities/(.*) /$1 break;
-
-        proxy_set_header        Host storage.googleapis.com;
-        proxy_pass              https://storage.googleapis.com:443/{{ sortinghat_assets_bucket }}$uri;
-        proxy_http_version      1.1;
-        proxy_set_header        Connection "";
-        proxy_set_header        Cookie "";
-        proxy_set_header        Authorization "";
-        proxy_hide_header       x-goog-hash;
-        proxy_hide_header       x-goog-generation;
-        proxy_hide_header       x-goog-metageneration;
-        proxy_hide_header       x-goog-stored-content-encoding;
-        proxy_hide_header       x-goog-stored-content-length;
-        proxy_hide_header       x-goog-storage-class;
-        proxy_hide_header       x-guploader-uploadid;
-        proxy_hide_header       x-xss-protection;
-        proxy_hide_header       x-goog-meta-goog-reserved-file-mtime;
-        proxy_hide_header       accept-ranges;
-        proxy_hide_header       alternate-protocol;
-        proxy_hide_header       Set-Cookie;
-        proxy_hide_header       Expires;
-        proxy_hide_header       Cache-Control;
-        proxy_ignore_headers    Set-Cookie;
-        proxy_intercept_errors  on;
-        proxy_method            GET;
-        proxy_pass_request_body off;
+      rewrite ^/identities/(.*)$ /$1 break;
+      root /opt/gcs/;
     }
 }
+

--- a/terraform/modules/bap_env_gcp/storage.tf
+++ b/terraform/modules/bap_env_gcp/storage.tf
@@ -7,7 +7,7 @@ resource "google_storage_bucket" "backups_assets" {
   name         = random_id.backups_assets_bucket_id.hex
   location     = var.backups_storage_location
 
-  uniform_bucket_level_access = false
+  uniform_bucket_level_access = var.uniform_bucket_level_access
   force_destroy = true
 }
 
@@ -20,18 +20,7 @@ resource "google_storage_bucket" "sortinghat_assets" {
   name         = random_id.sortinghat_assets_bucket_id.hex
   location     = var.sortinghat_storage_location
 
-  uniform_bucket_level_access = false
+  uniform_bucket_level_access = var.uniform_bucket_level_access
   force_destroy = true
 }
 
-resource "google_storage_bucket_access_control" "public_rule" {
-  bucket = google_storage_bucket.sortinghat_assets.name
-  role   = "READER"
-  entity = "allUsers"
-}
-
-resource "google_storage_bucket_iam_binding" "binding_allUsers" {
-  bucket = google_storage_bucket.sortinghat_assets.name
-  role = "roles/storage.objectViewer"
-  members = ["allUsers"]
-}

--- a/terraform/modules/bap_env_gcp/variables.tf
+++ b/terraform/modules/bap_env_gcp/variables.tf
@@ -300,3 +300,9 @@ variable "sortinghat_storage_location" {
   type    = string
   default = "EUROPE-SOUTHWEST1"
 }
+
+variable "uniform_bucket_level_access" {
+  type = bool
+  default = false
+}
+


### PR DESCRIPTION
These commits change the way Nginx serves SortingHat static files,
using local files synced from GCS bucket instead of accesing
remotely. Public access to bucket is not longer available.