### PR TITLE
[ansible] Remove gsutil rsync bucket in restore opensearch role

### DIFF
--- a/ansible/roles/opensearch/defaults/main.yml
+++ b/ansible/roles/opensearch/defaults/main.yml
@@ -58,7 +58,7 @@ opensearch_base_path: opensearch
 #backups_assets_bucket: bap-opensearch-snapshots-<XXXXXXXX>
 opensearch_snapshots_repo_type: gcs
 opensearch_snapshots_repository: os_backups
-opensearch_snapshots_es_url: https://localhost:9200
+opensearch_snapshots_url: https://localhost:9200
 opensearch_snapshots_index_list:
   - "*"
 
@@ -67,6 +67,8 @@ opensearch_snapshots_index_list:
 # Remember to remove or comment this section after the snapshot is restored.
 #restore_snapshot:
 #  bucket: <BUCKET-NAME>
+#  base_path: <BUCKET-BASE-PATH>
+#  repository: <SNAPSHOT-REPOSITORY>
 #  name: <SNAPSHOT-NAME>
 #  index_list: "-.opendistro_security,-security-auditlog*,-.kibana_1"
 

--- a/ansible/roles/opensearch/tasks/snapshots.yml
+++ b/ansible/roles/opensearch/tasks/snapshots.yml
@@ -36,7 +36,7 @@
 
 - name: Reload opensearch secure settings
   uri:
-    url: "{{ opensearch_snapshots_es_url }}/_nodes/reload_secure_settings"
+    url: "{{ opensearch_snapshots_url }}/_nodes/reload_secure_settings"
     method: POST
     client_cert: "{{ certs_dir }}/{{ certs_files.admin_cert }}"
     client_key: "{{ certs_dir }}/{{ certs_files.admin_key }}"
@@ -58,10 +58,9 @@
   ignore_errors: true
   changed_when: false
 
-- name: "Create snapshot repository '{{ opensearch_snapshots_repository }}' \
-    in GCS bucket '{{ backups_assets_bucket }}'"
+- name: "Create snapshot repository '{{ opensearch_snapshots_repository }}'"
   uri:
-    url: "{{ opensearch_snapshots_es_url }}/_snapshot/{{ opensearch_snapshots_repository }}"
+    url: "{{ opensearch_snapshots_url }}/_snapshot/{{ opensearch_snapshots_repository }}"
     method: PUT
     body_format: json
     body:
@@ -74,15 +73,25 @@
     validate_certs: false
   run_once: true
 
-- name: "Rsync OpenSearch snapshot bucket from {{ restore_snapshot.bucket }} to {{ backups_assets_bucket }}"
-  command: "gsutil -m rsync -r -d -p gs://{{ restore_snapshot.bucket }} gs://{{ backups_assets_bucket }}"
-  delegate_to: localhost
+- name: "Create snapshot repository '{{ restore_snapshot.repository }}'"
+  uri:
+    url: "{{ opensearch_snapshots_url }}/_snapshot/{{ restore_snapshot.repository }}"
+    method: PUT
+    body_format: json
+    body:
+      type: "{{ opensearch_snapshots_repo_type }}"
+      settings:
+        bucket: "{{ restore_snapshot.bucket }}"
+        base_path: "{{ restore_snapshot.base_path }}"
+    client_cert: "{{ certs_dir }}/{{ certs_files.admin_cert }}"
+    client_key: "{{ certs_dir }}/{{ certs_files.admin_key }}"
+    validate_certs: false
   run_once: true
   when: restore_snapshot is defined
 
-- name: "Restore indices from {{ opensearch_snapshots_repository }} of {{ backups_assets_bucket }} bucket"
+- name: "Restore indices from {{ restore_snapshot.repository }} of {{ restore_snapshot.bucket }} bucket"
   uri:
-    url: "{{ opensearch_snapshots_es_url }}/_snapshot/{{ opensearch_snapshots_repository }}/{{ restore_snapshot.name }}/_restore"
+    url: "{{ opensearch_snapshots_url }}/_snapshot/{{ restore_snapshot.repository }}/{{ restore_snapshot.name }}/_restore"
     method: POST
     body_format: json
     body:

--- a/ansible/roles/opensearch/templates/make_snapshot.sh.j2
+++ b/ansible/roles/opensearch/templates/make_snapshot.sh.j2
@@ -6,6 +6,6 @@ set -euo pipefail
 curl -s -XPUT -k --cert "{{ certs_dir }}/{{ certs_files.admin_cert }}" \
 --key "{{ certs_dir }}/{{ certs_files.admin_key }}" \
 -H "Content-Type: application/json" -d "@{{ opensearch_snapshots_json_file }}" \
--k "{{ opensearch_snapshots_es_url }}/_snapshot/{{ opensearch_snapshots_repository }}/\
+-k "{{ opensearch_snapshots_url }}/_snapshot/{{ opensearch_snapshots_repository }}/\
 %3Csnapshot-%7Bnow%7Byyyy.MM.dd%7D%7D%3E?wait_for_completion=false&pretty" | tee /dev/tty \
 | jq -e '.accepted == true' >/dev/null


### PR DESCRIPTION
This commit removes the `gsutil resync` between buckets when the `restore_snapshot` is defined (it will take very long, maybe days if there are a lot of data). Instead of that it will restore the snapshot from the old bucket to the new OpenSearch instance.