### PR TITLE
Support private and anonymous OpenSearch Dashboards

### DIFF
--- a/ansible/playbooks/nginx.yml
+++ b/ansible/playbooks/nginx.yml
@@ -9,6 +9,7 @@
       with_items:
         - "{{ groups['opensearch'] }}"
         - "{{ groups['opensearch_dashboards'] }}"
+        - "{{ groups['opensearch_dashboards_anonymous'] }}"
         - "{{ groups['sortinghat'] }}"
   roles:
     - nginx

--- a/ansible/playbooks/opensearch_dashboards.yml
+++ b/ansible/playbooks/opensearch_dashboards.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: opensearch_dashboards
+- hosts: opensearch_dashboards, opensearch_dashboards_anonymous
   pre_tasks:
     - name: Gather facts from OpenSearch nodes
       setup:

--- a/ansible/playbooks/sortinghat.yml
+++ b/ansible/playbooks/sortinghat.yml
@@ -1,5 +1,14 @@
 ---
 - hosts: sortinghat
+  pre_tasks:
+    - name: Gather facts from other service nodes
+      setup:
+      delegate_to: "{{ item }}"
+      delegate_facts: true
+      when: hostvars[item]['ansible_default_ipv4'] is not defined
+      with_items:
+        - "{{ groups['opensearch_dashboards'] }}"
+        - "{{ groups['opensearch_dashboards_anonymous'] }}"
   roles:
     - sortinghat
   become: true

--- a/ansible/roles/mordred/tasks/configure_instance.yml
+++ b/ansible/roles/mordred/tasks/configure_instance.yml
@@ -71,11 +71,15 @@
   with_items:
     - "{{ mariadb_hosts }}"
 
+- name: Set anonymous role if opensearch_dashboards_anonymous is defined
+  set_fact:
+    anonymous: "{% if groups['opensearch_dashboards_anonymous'] %} '-a' {% else %} '' {% endif %}"
+
 - name: "Create roles and tenant for {{ instance.project }}"
   become: false
   command: >-
     python3 {{ role_path }}/files/create_roles_tenant.py
-    https://{{ opensearch_admin_user }}:{{ opensearch_admin_password }}@{{ groups['opensearch'][0] }}:9200 {{ instance.tenant }}
+    https://{{ opensearch_admin_user }}:{{ opensearch_admin_password }}@{{ groups['opensearch'][0] }}:9200 {{ instance.tenant }} {{ anonymous }}
   delegate_to: localhost
 
 - name: "Create mordred user for {{ instance.project }}"
@@ -83,6 +87,7 @@
     url: "https://{{ groups['opensearch'][0] }}:9200/_plugins/_security/api/internalusers/{{ instance.tenant }}_mordred"
     url_username: "{{ opensearch_admin_user }}"
     url_password: "{{ opensearch_admin_password }}"
+    force_basic_auth: yes
     method: PUT
     status_code: 200
     body_format: json

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -8,13 +8,18 @@ nginx_docker_container: nginx
 nginx_workdir: "/docker/nginx"
 nginx_virtualhosts_workdir: "{{ nginx_workdir }}/conf"
 
-virtualhost:
-  fqdn: example.com
+# Create your Nginx virtual host configurations
+## nginx_virtualhosts:
+##  - fqdn: example.com
+##    public: false
+##    tenant: example
+##  - fqdn: example-public.com
+##    public: true
+##    tenant: example-public
 
 # Service hosts
-opensearch_dashboards_endpoint: "https://{{ hostvars[(groups['opensearch_dashboards'] | first)].ansible_default_ipv4.address }}:5601"
-opensearch_endpoint: "https://{{ hostvars[(groups['opensearch'] | first)].ansible_default_ipv4.address }}:9200"
-sortinghat_host: "{{ hostvars[(groups['sortinghat'] | first)].ansible_default_ipv4.address }}:9314"
+opensearch_endpoint: "https://{{ hostvars[(groups['opensearch'][0])].ansible_default_ipv4.address }}:9200"
+sortinghat_host: "{{ hostvars[(groups['sortinghat'][0])].ansible_default_ipv4.address }}:9314"
 
 # Certificates configuration
 

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -2,6 +2,9 @@
 
 - name: Configure virtualhost(s)
   include_tasks: virtualhost.yml
+  loop: "{{ nginx_virtualhosts }}"
+  loop_control:
+    loop_var: instance
 
 - name: Configure NGINX proxy buffer sizes
   template:
@@ -14,14 +17,26 @@
     name: "{{ nginx_docker_container }}"
     state: absent
 
+- name: Create docker volumes for certs and config
+  set_fact:
+    volumes_certs: |-
+      [
+      {% for instance in nginx_virtualhosts %}
+        "{{ certs_dir }}/{{ instance.fqdn }}.crt:/etc/ssl/certs/{{ instance.fqdn }}.crt",
+        "{{ certs_dir }}/{{ instance.fqdn }}.key:/etc/ssl/private/{{ instance.fqdn }}.key",
+      {% endfor %}
+        "{{ nginx_virtualhosts_workdir}}:/etc/nginx/conf.d/"
+      ]
+
+- name: Check the list of volumes
+  debug:
+    msg: "{{ volumes_certs }}"
+
 - name: Start NGINX container
   docker_container:
     name: "{{ nginx_docker_container }}"
     image: "{{ nginx_docker_image }}:{{ nginx_version }}"
-    volumes:
-      - "{{ nginx_virtualhosts_workdir}}:/etc/nginx/conf.d/"
-      - "{{ certs_dir }}/{{ virtualhost.fqdn }}.crt:/etc/ssl/certs/{{ virtualhost.fqdn }}.crt"
-      - "{{ certs_dir }}/{{ virtualhost.fqdn }}.key:/etc/ssl/private/{{ virtualhost.fqdn }}.key"
+    volumes: "{{ volumes_certs }}"
     ports:
       - "80:80"
       - "443:443"

--- a/ansible/roles/nginx/tasks/virtualhost.yml
+++ b/ansible/roles/nginx/tasks/virtualhost.yml
@@ -14,8 +14,8 @@
     mode: 0750
     recurse: true
 
-- name: "Generate self-signed certificate for {{ virtualhost.fqdn }}"
-  shell: "./generate_cert.sh {{ virtualhost.fqdn }}"
+- name: "Generate self-signed certificate for {{ instance.fqdn }}"
+  shell: "./generate_cert.sh {{ instance.fqdn }}"
   become: false
   args:
     chdir: "{{ role_path }}/files"
@@ -23,7 +23,7 @@
   delegate_to: localhost
   when: custom_cert is not defined
 
-- name: "Copy SSL certificate for {{ virtualhost.fqdn }}"
+- name: "Copy SSL certificate for {{ instance.fqdn }}"
   copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
@@ -32,25 +32,25 @@
     mode: "{{ item.mode }}"
   loop:
     - src: "{{ custom_cert.cert if custom_cert is defined else 'cert.crt' }}"
-      dest: "{{ certs_dir }}/{{ virtualhost.fqdn }}.crt"
+      dest: "{{ certs_dir }}/{{ instance.fqdn }}.crt"
       owner: '1000'
       group: '1000'
       mode: '0644'
     - src: "{{ custom_cert.key if custom_cert is defined else 'cert.key' }}"
-      dest: "{{ certs_dir }}/{{ virtualhost.fqdn }}.key"
+      dest: "{{ certs_dir }}/{{ instance.fqdn }}.key"
       owner: '1000'
       group: '1000'
       mode: '0600'
   loop_control:
     label: "{{ item.dest }}"
 
-- name: "Create virtualhost configuration for {{ virtualhost.fqdn }}"
+- name: "Create virtualhost configuration for {{ instance.fqdn }}"
   template:
     src: "{{ item.template }}"
     dest: "{{ nginx_virtualhosts_workdir }}/{{ item.name }}"
     backup: true
   with_items:
-    - name: "{{ virtualhost.fqdn }}.conf"
+    - name: "{{ instance.fqdn }}.conf"
       template: vhost.j2
-    - name: "{{ virtualhost.fqdn }}_uwsgi_params"
+    - name: "{{ instance.fqdn }}_uwsgi_params"
       template: uwsgi_params.j2

--- a/ansible/roles/nginx/templates/vhost.j2
+++ b/ansible/roles/nginx/templates/vhost.j2
@@ -1,12 +1,8 @@
-upstream sortinghat {
-    server {{ sortinghat_host }};
-}
-
 server {
     listen 80;
-    server_name {{ virtualhost.fqdn }};
+    server_name {{ instance.fqdn }};
 
-    return 301 https://{{ virtualhost.fqdn }};
+    return 301 https://{{ instance.fqdn }};
 }
 
 server {
@@ -14,15 +10,15 @@ server {
     sendfile   on;
 
     listen 443 ssl http2;
-    server_name {{ virtualhost.fqdn }};
+    server_name {{ instance.fqdn }};
 
     # Needed by OpenSearch Dashboards queries
     client_max_body_size 2000M;
 
     ssl    on;
 
-    ssl_certificate /etc/ssl/certs/{{ virtualhost.fqdn }}.crt;
-    ssl_certificate_key /etc/ssl/private/{{ virtualhost.fqdn }}.key;
+    ssl_certificate /etc/ssl/certs/{{ instance.fqdn }}.crt;
+    ssl_certificate_key /etc/ssl/private/{{ instance.fqdn }}.key;
 
     ssl_protocols TLSv1.3 TLSv1.2;
     ssl_ciphers AES256+EECDH:AES256+EDH:!aNULL;
@@ -35,30 +31,26 @@ server {
 
     rewrite ^/$ /app/dashboards#/view/Overview permanent;
     location / {
-        proxy_pass {{ opensearch_dashboards_endpoint }}/;
-        proxy_redirect {{ opensearch_dashboards_endpoint }}/ /;
+{% if instance.public is defined and instance.public == true %}
+        proxy_pass https://{{ hostvars[(groups['opensearch_dashboards_anonymous'][0])].ansible_default_ipv4.address }}:5601/;
+        proxy_redirect https://{{ hostvars[(groups['opensearch_dashboards_anonymous'][0])].ansible_default_ipv4.address }}:5601/ /;
+{% else %}
+        proxy_pass https://{{ hostvars[(groups['opensearch_dashboards'][0])].ansible_default_ipv4.address }}:5601/;
+        proxy_redirect https://{{ hostvars[(groups['opensearch_dashboards'][0])].ansible_default_ipv4.address }}:5601/ /;
+{% endif %}
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
-    }
-
-    location /data/ {
-        proxy_pass {{ opensearch_endpoint }}/;
-        proxy_http_version 1.1;
-        proxy_set_header Connection "Keep-Alive";
-        proxy_set_header Proxy-Connection "Keep-Alive";
-        client_max_body_size 2000M;
-        proxy_read_timeout 300;
-        proxy_send_timeout 240;
+        proxy_set_header security_tenant {{ instance.tenant }};
     }
 
     location /identities {
         rewrite                 ^/identities/(.*) /$1 break;
 
-        include /etc/nginx/conf.d/{{ virtualhost.fqdn }}_uwsgi_params;
-        uwsgi_pass sortinghat;
+        include /etc/nginx/conf.d/{{ instance.fqdn }}_uwsgi_params;
+        uwsgi_pass {{ sortinghat_host }};
         uwsgi_param Host $host;
         uwsgi_param X-Real-IP $remote_addr;
         uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/ansible/roles/opensearch_dashboards/defaults/main.yml
+++ b/ansible/roles/opensearch_dashboards/defaults/main.yml
@@ -23,7 +23,6 @@ opensearch:
   username: kibanaserver
   password: "{{ opensearch_dashboards_password }}"
 
-anonymous_auth_enabled: false
 login:
   title: "Please login to Bitergia Analytics Dashboard."
   subtitle: "If you have forgotten your username or password, please contact the Bitergia staff."

--- a/ansible/roles/opensearch_dashboards/tasks/main.yml
+++ b/ansible/roles/opensearch_dashboards/tasks/main.yml
@@ -15,12 +15,21 @@
     group: '1000'
     mode: 0644
 
-- name: Remove old OpenSearch Dashboards container
+- name: Remove old private OpenSearch Dashboards container
   docker_container:
     name: "{{ opensearch_dashboards_docker_container }}"
     state: absent
+  delegate_to: "{{ groups['opensearch_dashboards'][0] }}"
+  when: inventory_hostname in groups['opensearch_dashboards']
 
-- name: Start OpenSearch Dashboards container(s)
+- name: Remove old anonymous OpenSearch Dashboards container
+  docker_container:
+    name: "{{ opensearch_dashboards_docker_container }}_anonymous"
+    state: absent
+  delegate_to: "{{ groups['opensearch_dashboards_anonymous'][0] }}"
+  when: inventory_hostname in groups['opensearch_dashboards_anonymous']
+
+- name: Start private OpenSearch Dashboards container(s)
   docker_container:
     name: "{{ opensearch_dashboards_docker_container }}"
     image: "{{ opensearch_dashboards_docker_image }}:{{ opensearch_dashboards_version }}"
@@ -30,3 +39,18 @@
       - "{{ opensearch_dashboards_workdir }}/opensearch_dashboards.yml:/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml"
     ports:
       - "{{ network.bind_host }}:5601:5601"
+  delegate_to: "{{ groups['opensearch_dashboards'][0] }}"
+  when: inventory_hostname in groups['opensearch_dashboards']
+
+- name: Start anonymous OpenSearch Dashboards container(s)
+  docker_container:
+    name: "{{ opensearch_dashboards_docker_container }}_anonymous"
+    image: "{{ opensearch_dashboards_docker_image }}:{{ opensearch_dashboards_version }}"
+    env:
+      NODE_OPTIONS=--max-old-space-size=1000
+    volumes:
+      - "{{ opensearch_dashboards_workdir }}/opensearch_dashboards.yml:/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml"
+    ports:
+      - "{{ network.bind_host }}:5601:5601"
+  delegate_to: "{{ groups['opensearch_dashboards_anonymous'][0] }}"
+  when: inventory_hostname in groups['opensearch_dashboards_anonymous']

--- a/ansible/roles/opensearch_dashboards/templates/opensearch_dashboards.yml.j2
+++ b/ansible/roles/opensearch_dashboards/templates/opensearch_dashboards.yml.j2
@@ -17,7 +17,12 @@ opensearch_security.readonly_mode.roles:
   - "kibana_read_only"
   - "bap_anonymous_access_role"
 
-opensearch_security.auth.anonymous_auth_enabled: {{ anonymous_auth_enabled }}
+# Anonymous user opendistro_security_anonymous
+{% if inventory_hostname in groups['opensearch_dashboards_anonymous'] %}
+opensearch_security.auth.anonymous_auth_enabled: true
+{% else %}
+opensearch_security.auth.anonymous_auth_enabled: false
+{% endif %}
 
 # Use this setting if you are running OpenSearch Dashboards without HTTPS
 opensearch_security.cookie.secure: false
@@ -44,7 +49,7 @@ server.ssl.key: "/usr/share/opensearch-dashboards/config/{{ opensearch_dashboard
 server.ssl.enabled: true
 {% endif %}
 
-{% if openid is defined %}
+{% if openid_dashboards is defined %}
 ### OpenID configuration
 opensearch_security.auth.type: "openid"
 opensearch_security.openid.connect_url: "{{ openid.connect_url }}"

--- a/ansible/roles/sortinghat/defaults/main.yml
+++ b/ansible/roles/sortinghat/defaults/main.yml
@@ -16,8 +16,10 @@ network:
   bind_host: 0.0.0.0
   publish_host: "{{ ansible_default_ipv4.address }}"
 
-virtualhost:
-  fqdn: example.com
+# Nginx virtual hosts
+nginx_virtualhosts:
+  - fqdn: example.com
+  - fqdn: example2.com
 
 # Database
 sortinghat_database: sortinghat_db
@@ -30,8 +32,8 @@ redis_hosts: "{{ groups['redis'] | first }}"
 sortinghat_debug: "false"
 
 # CSRF and CORS configuration
-sortinghat_allowed_hosts: "{{ virtualhost.fqdn }},{{ groups['sortinghat'][0] }},{{ groups['mordred'][0] }}"
-sortinghat_cors_allowed_origins: "https://{{ virtualhost.fqdn }},https://{{ groups['sortinghat'][0] }},https://{{ groups['mordred'][0] }}"
+sortinghat_allowed_hosts: "{{ groups['sortinghat'][0] }},{{ groups['mordred'][0] }}"
+sortinghat_cors_allowed_origins: "https://{{ groups['sortinghat'][0] }},https://{{ groups['mordred'][0] }}"
 
 # NGINX
 

--- a/ansible/roles/sortinghat/tasks/main.yml
+++ b/ansible/roles/sortinghat/tasks/main.yml
@@ -35,6 +35,16 @@
     name: "{{ sortinghat_docker_container }}"
     state: absent
 
+- name: Add sortinghat_allowed_hosts
+  set_fact:
+    sortinghat_allowed_hosts: "{{ sortinghat_allowed_hosts + ',' + item.fqdn }}"
+  loop: "{{ nginx_virtualhosts }}"
+
+- name: Add sortinghat_cors_allowed_origins
+  set_fact:
+    sortinghat_cors_allowed_origins: "{{ sortinghat_cors_allowed_origins + ',' + 'https://'+item.fqdn }}"
+  loop: "{{ nginx_virtualhosts }}"
+
 - name: Start SortingHat container
   docker_container:
     name: "{{ sortinghat_docker_container }}"

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -142,8 +142,14 @@ all:
       sources:
         repository: "<repo_teneant_b_projects.git>"
 
-    virtualhost:
-      fqdn: <fqdn>
+    # OpenSearch Dashboards Settings for Nginx
+    nginx_virtualhosts:
+      - fqdn: <fqdn-1>
+        public: false
+        tenant: <tenant_name_a>
+      - fqdn: <fqdn-2>
+        public: true
+        tenant: <tenant_name_b>
 ```
 
 Replace the entries in `<>` with your values:
@@ -191,8 +197,13 @@ Replace the entries in `<>` with your values:
   [terraform prefix](https://github.com/bitergia-analytics/bap-deployment-toolkit/blob/main/docs/provision.md#gcp-module-settings-environmenttf).
 - `sortinghat_bucket_provider`: cloud provider type; valid values are: `gcp`.
 - `sortinghat_workers`: number of SortingHat Workers (by default is `1`)
-- `virtualhost.fqdn`: full qualified domain name (e.g. `bap.example.com`)
+- `nginx_virtualhosts`: Nginx virtual host configurations.
+- `nginx_virtualhosts.fqdn`: full qualified domain name (e.g. `bap.example.com`)
   where BAP will be available.
+- `nginx_virtualhosts.public`: OpenSearch Dashboards with anonymous access `true | false`. If
+  the variable is not defined the OpenSearch Dashboards is private.
+- `nginx_virtualhosts.tenant`: the name of the tenant for this OpenSearch Dashboards endpoint,
+  it must be same as `mordred_instances.tenant`.
 
 After configuring these parameters, you need to configure the instances of the
 task scheduler (Mordred). You need a task scheduler for each project you want

--- a/docs/provision.md
+++ b/docs/provision.md
@@ -101,6 +101,22 @@ You can set the number of nodes and virtual machine type for each component
 of the architecture. Take the next example as reference for a large project
 but adapt them to your necessities.
 
+You can create different OpenSearch Dashboards machines depends on your needs.
+We have three scenarios for OpenSearch Dashboards:
+
+1. One OpenSearch Dashboards `without anonymous` access.
+    - `opensearch_dashboards_node_count = 1`
+    - `opensearch_dashboards_anonymous_node_count = 0`
+2. One OpenSearch Dashboards `with anonymous` access.
+    - `opensearch_dashboards_node_count = 0`
+    - `opensearch_dashboards_anonymous_node_count = 1`
+3. Two OpenSearch Dashboards `one with anonymous` access and the `other not`.
+    - `opensearch_dashboards_node_count = 1`
+    - `opensearch_dashboards_anonymous_node_count = 1`
+
+Ansible will provision the OpenSearch Dashboard machines depending on which
+group the hostname belongs to.
+
 ```tf
 module "bap_env_gcp" {
   source = "../../modules/bap_env_gcp"
@@ -117,6 +133,7 @@ module "bap_env_gcp" {
   opensearch_machine_type = "e2-highmem-4"
 
   opensearch_dashboards_node_count = 1
+  opensearch_dashboards_anonymous_node_count = 0
   opensearch_dashboards_machine_type = "e2-highmem-4"
 
   nginx_node_count = 1

--- a/terraform/modules/bap_env_gcp/opensearch_dashboard_anonymous.tf
+++ b/terraform/modules/bap_env_gcp/opensearch_dashboard_anonymous.tf
@@ -1,0 +1,24 @@
+module "opensearch_dashboards_anonymous" {
+  source = "../bap_gcp_instance"
+
+  prefix                  = var.prefix
+  name                    = "opensearch-dashboards-anonymous"
+  node_count              = var.opensearch_dashboards_anonymous_node_count
+  tags                    = ["opensearch-dashboards-anonymous"]
+  ansible_groups          = ["opensearch-dashboards-anonymous"]
+
+  machine_type            = var.opensearch_dashboards_machine_type
+  machine_image           = var.opensearch_dashboards_machine_image
+  disk_size               = var.opensearch_dashboards_disk_size
+  disk_type               = var.opensearch_dashboards_disk_type
+  zone                    = var.zone
+
+  network                 = var.network
+  subnetwork              = var.subnetwork
+  enable_external_ip      = false
+  ansible_use_external_ip = var.opensearch_dashboards_ansible_use_external_ip
+}
+
+output "opensearch_dashboards_anonymous" {
+  value = module.opensearch_dashboards_anonymous
+}

--- a/terraform/modules/bap_env_gcp/variables.tf
+++ b/terraform/modules/bap_env_gcp/variables.tf
@@ -129,6 +129,11 @@ variable "opensearch_dashboards_node_count" {
   default = 1
 }
 
+variable "opensearch_dashboards_anonymous_node_count" {
+  type    = number
+  default = 0
+}
+
 variable "opensearch_dashboards_machine_type" {
   type    = string
   # default = "e2-highmem-4" # 4vcpu, 32GB memory


### PR DESCRIPTION
This commit creates a new terraform file in the `bap_env_gcp` module named `opensearch_dashboard_anonymous.tf` to create a machine for OpenSearch Dashboards with anonymous access.

Also, update the Ansible `opensearch_dashboards` role. Depending on whether the hostname belongs to the `opensearch_dashboards` inventory group, it will deploy OpenSearch Dashboards disabling the anonymous user, but if it belongs to the
`opensearch_dashboards_anonymous` inventory group, it will deploy OpenSearch Dashboards with the anonymous user.