### PR TITLE
[mordred] Allow custom SSH key pair

### DIFF
--- a/ansible/roles/mordred/defaults/main.yml
+++ b/ansible/roles/mordred/defaults/main.yml
@@ -8,6 +8,10 @@ bap_version: 0.7.1
 mordred_workdir: "/docker/mordred"
 mordred_setups_dir: "{{ mordred_workdir }}/setups"
 mordred_ssh_dir: "{{ mordred_workdir }}/ssh"
+# Set in your environments vars.yml to add a custom SSH pair keys
+#mordred_ssh_key:
+#  private: "id_rsa"
+#  public: "id_rsa.pub"
 mordred_instances_dir: "{{ mordred_workdir }}/instances"
 
 mordred_aliases_url: https://raw.githubusercontent.com/chaoss/grimoirelab-sirmordred/master/aliases.json

--- a/ansible/roles/mordred/tasks/configure.yml
+++ b/ansible/roles/mordred/tasks/configure.yml
@@ -17,10 +17,27 @@
     path: "{{ mordred_ssh_dir }}/id_rsa"
   register: sshkey
 
+- name: Copy a custom SSH key pair
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - src: "{{ mordred_ssh_key.private }}"
+      dest: "{{ mordred_ssh_dir }}/id_rsa"
+      mode: '0750'
+    - src: "{{ mordred_ssh_key.public }}"
+      dest: "{{ mordred_ssh_dir }}/id_rsa.pub"
+      mode: '0750'
+  when:
+    - not sshkey.stat.exists
+    - mordred_ssh_key is defined
+
 - name: Create SSH key pair
   command: "ssh-keygen -t rsa -b 4096 -q -N '' -f {{ mordred_ssh_dir }}/id_rsa"
   when:
     - not sshkey.stat.exists
+    - mordred_ssh_key is not defined
 
 - name: Set SSH default config for user 'git'
   copy:

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -227,7 +227,7 @@ about how to setup the task scheduler.
 - `mordred_instances.mordred_password`: strong password for the modred user
    of this tenant.
 - `mordred_instances.sources.repository`: repository with the list of data
-   sources to analyze on this project
+   sources to analyze on this project.
 
 #### OpenID Configuration (Optional)
 
@@ -282,6 +282,29 @@ Replace the entries in `<>` with your values:
 
 - `custom_cert.cert`: path to your `.crt` or `.pem` certificate
 - `custom_cert.key`: path to your `.key` file
+
+#### SSH Keys for Non-Public Data Sources (Optional)
+
+Sometimes, data sources such as `git` or `gerrit` would require access using
+SSH protocol. For those cases, the platform generates a SSH key pair when it's
+deployed for the first time. However, these keys won't work for private
+repositories which require authentication. For those cases, you can provide your
+own SSH keys, setting their location on the `vars.yml` file under the
+`all.vars` section.
+
+As with other keys and certificates, we recommend to store the certificates under
+the `keys/<environment>` directory of this toolkit.
+
+```yaml
+    mordred_ssh_key:
+      private: "<path_to_private_ssh_key>"
+      public: "<path_to_public_ssh_key>"
+```
+
+Replace the entries in `<>` with your values:
+
+- `mordred_ssh_key.private`: path to your SSH private key file
+- `mordred_ssh_key.public`: path to your SSH public key file
 
 ## 3. Setup Ansible Authentication
 


### PR DESCRIPTION
This commit allows a custom SSH key pair by adding this section on the `main.yml`(defaults) or `vars.yml`(inventory).

```
mordred_ssh:
  private: "<SSH_PRIVATE_PATH>"
  public: "<SSH_PUBLIC_PATH>"
```

docs/deployment_and_config.md updated accordingly.