### PR TITLE
[mordred] Create grimore group and user with SSH key

### DIFF
--- a/ansible/roles/mordred/tasks/configure.yml
+++ b/ansible/roles/mordred/tasks/configure.yml
@@ -4,6 +4,8 @@
   file:
     path: "{{ item }}"
     state: directory
+    owner: grimoire
+    group: grimoire
     mode: 0750
     recurse: true
   with_items:
@@ -21,20 +23,32 @@
   copy:
     src: "{{ item.src }}"
     dest: "{{ item.dest }}"
+    owner: grimoire
+    group: grimoire
     mode: "{{ item.mode }}"
   loop:
     - src: "{{ mordred_ssh_key.private }}"
       dest: "{{ mordred_ssh_dir }}/id_rsa"
-      mode: '0750'
+      mode: '0600'
     - src: "{{ mordred_ssh_key.public }}"
       dest: "{{ mordred_ssh_dir }}/id_rsa.pub"
-      mode: '0750'
+      mode: '0644'
   when:
     - not sshkey.stat.exists
     - mordred_ssh_key is defined
 
-- name: Create SSH key pair
-  command: "ssh-keygen -t rsa -b 4096 -q -N '' -f {{ mordred_ssh_dir }}/id_rsa"
+- name: Copy grimoire user SSH key pair
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: grimoire
+    group: grimoire
+    remote_src: true
+  loop:
+    - src: "/home/grimoire/.ssh/id_rsa"
+      dest: "{{ mordred_ssh_dir }}/id_rsa"
+    - src: "/home/grimoire/.ssh/id_rsa.pub"
+      dest: "{{ mordred_ssh_dir }}/id_rsa.pub"
   when:
     - not sshkey.stat.exists
     - mordred_ssh_key is not defined
@@ -62,6 +76,8 @@
     label: "{{ instance.project }}"
 
 - name: Checkout mordred setups repo
+  become: true
+  become_user: grimoire
   git:
     repo: "{{ mordred_setups_repo_url }}"
     dest: "{{ mordred_setups_dir }}"

--- a/ansible/roles/mordred/tasks/configure_instance.yml
+++ b/ansible/roles/mordred/tasks/configure_instance.yml
@@ -8,8 +8,8 @@
   file:
     state: directory
     path: "{{ item }}"
-    owner: root
-    group: '1000'
+    owner: grimoire
+    group: grimoire
     mode: '0774'
   with_items:
     - "{{ instance_dir }}/conf"
@@ -29,11 +29,13 @@
   copy:
     src: "/tmp/{{ instance.tenant }}_aliases.json"
     dest: "{{ instance_dir }}/conf/aliases.json"
-    owner: '1000'
-    group: '1000'
+    owner: grimoire
+    group: grimoire
     mode: '0640'
 
 - name: Checkout sources repo
+  become: true
+  become_user: grimoire
   git:
     repo: "{{ instance.sources.repository }}"
     dest: "{{ instance_dir }}/sources"
@@ -44,8 +46,8 @@
   file:
     state: directory
     path: "{{ instance_dir }}/sources"
-    owner: root
-    group: '1000'
+    owner: grimoire
+    group: grimoire
     mode: '0774'
 
 - name: "Create cron job to pull changes from {{ instance.project }} sources repo"

--- a/ansible/roles/mordred/tasks/main.yml
+++ b/ansible/roles/mordred/tasks/main.yml
@@ -1,5 +1,18 @@
 ---
 
+- name: Create group grimoire
+  group:
+    name: grimoire
+    state: present
+
+- name: Create user grimoire
+  user:
+    name: grimoire
+    groups: grimoire
+    generate_ssh_key: yes
+    ssh_key_bits: 4096
+    ssh_key_file: .ssh/id_rsa
+
 - name: Configure Mordred
   import_tasks: configure.yml
 


### PR DESCRIPTION
This commit creates the `grimoire` group and user including SSH key for machine `mordred` with the correct permissions.