### PR TITLE
[mordred] Allows option to overwrite roles and tenant

### DIFF
--- a/ansible/roles/mordred/defaults/main.yml
+++ b/ansible/roles/mordred/defaults/main.yml
@@ -21,6 +21,7 @@ mordred_aliases_url: https://raw.githubusercontent.com/chaoss/grimoirelab-sirmor
 #mordred_instances:
 #  - project: project1
 #    tenant: project1
+#    overwrite_roles: true
 #    sources:
 #      repository: "<PROJECT1_SOURCE_REPO_URL>"
 #  - project: project2

--- a/ansible/roles/mordred/tasks/configure_instance.yml
+++ b/ansible/roles/mordred/tasks/configure_instance.yml
@@ -77,11 +77,16 @@
   set_fact:
     anonymous: "{% if 'opensearch_dashboards_anonymous' in groups and groups['opensearch_dashboards_anonymous'] %} -a {% else %} {% endif %}"
 
+- name: Add --force option (create_roles_tenat.py) if overwrite_roles is defined and the value is true
+  set_fact:
+    overwrite_roles: "{% if instance.overwrite_roles is defined and instance.overwrite_roles %} --force {% else %} {% endif %}"
+
 - name: "Create roles and tenant for {{ instance.project }}"
   become: false
   command: >-
     python3 {{ role_path }}/files/create_roles_tenant.py
     https://{{ opensearch_admin_user }}:{{ opensearch_admin_password }}@{{ groups['opensearch'][0] }}:9200 {{ instance.tenant }} {{ anonymous }}
+    {{ overwrite_roles }}
   delegate_to: localhost
 
 - name: "Create mordred user for {{ instance.project }}"

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -137,6 +137,7 @@ all:
     mordred_instances:
     - project: <project_a>
       tenant: <tenant_name_a>
+      overwrite_roles: <overwrite_roles>
       mordred_password: <mordred_tenant_a_password>
       sources:
         repository: "<repo_teneant_a_projects.git>"
@@ -224,6 +225,7 @@ about how to setup the task scheduler.
 - `mordred_instances.project`: name of the project to analyze.
 - `mordred_instances.tenant`: the name used here will be used to store the
    data from this project in a separate tenant from the others.
+- `mordred_instances.overwrite_roles` (optional): overwrite roles and tenant `true | false`.
 - `mordred_instances.mordred_password`: strong password for the modred user
    of this tenant.
 - `mordred_instances.sources.repository`: repository with the list of data


### PR DESCRIPTION
This commit allows the option to overwrite roles and tenant of a project only if the `overwrite_roles` variable is set to `true` in `mordred_instances`.

```
mordred_instances:
  - project: project1
    tenant: project1
    overwrite_roles: true
    sources:
      repository: "<PROJECT1_SOURCE_REPO_URL>"
```

docs/deployment_and_config.md updated accordingly.