### PR TITLE
[monitoring] Add monitoring role to customize config files

### DIFF
--- a/ansible/playbooks/monitoring.yml
+++ b/ansible/playbooks/monitoring.yml
@@ -1,7 +1,32 @@
-- name: Add GCP Ops Agent on hosts
-  hosts: all
+---
+- hosts: all, !ungrouped, !redis, !nginx, !mariadb
   become: true
-  roles:
-    - role: google-cloud-ops-agents-ansible
-      vars:
-        agent_type: ops-agent
+  tasks:
+    - name: All hosts except Redis, NGINX, and MariaDB
+      include_role:
+        name: monitoring
+        tasks_from: main
+
+- hosts: nginx
+  become: true
+  tasks:
+    - name: NGINX monitoring
+      include_role:
+        name: monitoring
+        tasks_from: nginx
+
+- hosts: redis
+  become: true
+  tasks:
+    - name: Redis monitoring
+      include_role:
+        name: monitoring
+        tasks_from: redis
+
+- hosts: mariadb
+  become: true
+  tasks:
+    - name: MariaDB monitoring
+      include_role:
+        name: monitoring
+        tasks_from: mariadb

--- a/ansible/roles/monitoring/defaults/main.yml
+++ b/ansible/roles/monitoring/defaults/main.yml
@@ -1,0 +1,17 @@
+# Docker logs
+docker_logging_include_paths: [/var/lib/docker/containers/*/*-json.log]
+
+# MariaDB
+mariadb_metric_endpoint: "{{ hostvars[groups['mariadb'][0]]['ansible_default_ipv4']['address'] }}:3306"
+mariadb_root_password: ""
+mariadb_root_user: root
+
+# NGINX
+nginx_logging_access_include_paths: ["/docker/nginx/log/access.log"]
+nginx_logging_error_include_paths: ["/docker/nginx/log/error.log"]
+nginx_metric_stub_status_url: "http://{{ hostvars[groups['nginx'][0]]['ansible_default_ipv4']['address'] }}:80/nginx_status"
+
+# Redis
+redis_logging_include_paths: ["/docker/redis/log/redis.log"]
+redis_metric_address: "{{ hostvars[groups['redis'][0]]['ansible_default_ipv4']['address'] }}:6379"
+redis_password: ""

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Create Docker logs Ops Agent YAML file
+  template:
+    src: docker_ops_agent.yaml.j2
+    dest: /tmp/docker_ops_agent.yaml
+  delegate_to: localhost
+
+- name: Add GCP Ops Agent on hosts
+  include_role:
+    name: google-cloud-ops-agents-ansible
+  vars:
+    agent_type: ops-agent
+    main_config_file: /tmp/docker_ops_agent.yaml
+
+- name: Clean up Docker logs Ops Agent YAML file
+  file:
+    path: /tmp/docker_ops_agent.yaml
+    state: absent
+  delegate_to: localhost

--- a/ansible/roles/monitoring/tasks/mariadb.yml
+++ b/ansible/roles/monitoring/tasks/mariadb.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Create MariaDB Ops Agent YAML file
+  template:
+    src: mariadb_ops_agent.yaml.j2
+    dest: /tmp/mariadb_ops_agent.yaml
+  delegate_to: localhost
+
+- name: Add GCP MariaDB Ops Agent
+  include_role:
+    name: google-cloud-ops-agents-ansible
+  vars:
+    agent_type: ops-agent
+    main_config_file: /tmp/mariadb_ops_agent.yaml
+
+- name: Clean up MariaDB Ops Agent YAML file
+  file:
+    path: /tmp/mariadb_ops_agent.yaml
+    state: absent
+  delegate_to: localhost

--- a/ansible/roles/monitoring/tasks/nginx.yml
+++ b/ansible/roles/monitoring/tasks/nginx.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Create NGINX Ops Agent YAML file
+  template:
+    src: nginx_ops_agent.yaml.j2
+    dest: /tmp/nginx_ops_agent.yaml
+  delegate_to: localhost
+
+- name: Add GCP NGINX Ops Agent
+  include_role:
+    name: google-cloud-ops-agents-ansible
+  vars:
+    agent_type: ops-agent
+    main_config_file: /tmp/nginx_ops_agent.yaml
+
+- name: Clean up NGINX Ops Agent YAML file
+  file:
+    path: /tmp/nginx_ops_agent.yaml
+    state: absent
+  delegate_to: localhost

--- a/ansible/roles/monitoring/tasks/redis.yml
+++ b/ansible/roles/monitoring/tasks/redis.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Create Redis Ops Agent YAML file
+  template:
+    src: redis_ops_agent.yaml.j2
+    dest: /tmp/redis_ops_agent.yaml
+  delegate_to: localhost
+
+- name: Add GCP Redis Ops Agent
+  include_role:
+    name: google-cloud-ops-agents-ansible
+  vars:
+    agent_type: ops-agent
+    main_config_file: /tmp/redis_ops_agent.yaml
+
+- name: Clean up Redis Ops Agent YAML file
+  file:
+    path: /tmp/redis_ops_agent.yaml
+    state: absent
+  delegate_to: localhost

--- a/ansible/roles/monitoring/templates/docker_ops_agent.yaml.j2
+++ b/ansible/roles/monitoring/templates/docker_ops_agent.yaml.j2
@@ -1,0 +1,16 @@
+logging:
+  receivers:
+    docker-logs:
+      type: files
+      include_paths: {{ docker_logging_include_paths }}
+      record_log_file_path: true
+  processors:
+    parse_json:
+      type: parse_json
+      time_key: time
+      time_format: "%Y-%m-%dT%H:%M:%S.%L"
+  service:
+    pipelines:
+      pipeline:
+        receivers: [docker-logs]
+        processors: [parse_json]

--- a/ansible/roles/monitoring/templates/mariadb_ops_agent.yaml.j2
+++ b/ansible/roles/monitoring/templates/mariadb_ops_agent.yaml.j2
@@ -1,0 +1,14 @@
+{% include 'docker_ops_agent.yaml.j2' %}
+
+metrics:
+  receivers:
+    mysql:
+      type: mysql
+      endpoint: {{ mariadb_metric_endpoint }}
+      password: {{ mariadb_root_password }}
+      username: {{ mariadb_root_user }}
+  service:
+    pipelines:
+      mysql:
+        receivers:
+          - mysql

--- a/ansible/roles/monitoring/templates/nginx_ops_agent.yaml.j2
+++ b/ansible/roles/monitoring/templates/nginx_ops_agent.yaml.j2
@@ -1,0 +1,25 @@
+logging:
+  receivers:
+    nginx_access:
+      type: nginx_access
+      include_paths: {{ nginx_logging_access_include_paths }}
+    nginx_error:
+      type: nginx_error
+      include_paths: {{ nginx_logging_error_include_paths }}
+  service:
+    pipelines:
+      nginx:
+        receivers:
+          - nginx_access
+          - nginx_error
+metrics:
+  receivers:
+    nginx:
+      type: nginx
+      stub_status_url: {{ nginx_metric_stub_status_url }}
+      collection_interval: 60s
+  service:
+    pipelines:
+      nginx:
+        receivers:
+          - nginx

--- a/ansible/roles/monitoring/templates/redis_ops_agent.yaml.j2
+++ b/ansible/roles/monitoring/templates/redis_ops_agent.yaml.j2
@@ -1,0 +1,21 @@
+logging:
+  receivers:
+    redis:
+      type: redis
+      include_paths: {{ redis_logging_include_paths }}
+  service:
+    pipelines:
+      redis:
+        receivers:
+        - redis
+metrics:
+  receivers:
+    redis:
+      type: redis
+      address: {{ redis_metric_address }}
+      password: {{ redis_password }}
+  service:
+    pipelines:
+      redis:
+        receivers:
+        - redis

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -7,6 +7,7 @@ nginx_docker_container: nginx
 # NGINX node configuration
 nginx_workdir: "/docker/nginx"
 nginx_virtualhosts_workdir: "{{ nginx_workdir }}/conf"
+nginx_log_dir: "{{ nginx_workdir }}/log"
 
 # Create your Nginx virtual host configurations
 ## nginx_virtualhosts:

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 
+- name: Configure NGINX status page
+  template:
+    src: status.conf.j2
+    dest: "{{ nginx_virtualhosts_workdir }}/status.conf"
+
 - name: Configure virtualhost(s)
   include_tasks: virtualhost.yml
   loop: "{{ nginx_virtualhosts }}"
@@ -29,7 +34,8 @@
         "{{ certs_dir }}/{{ instance.fqdn }}.key:/etc/ssl/private/{{ instance.fqdn }}.key",
       {% endfor %}
         "{{ nginx_virtualhosts_workdir}}:/etc/nginx/conf.d/",
-        "{{ nginx_gcs_workdir }}:/opt/gcs"
+        "{{ nginx_gcs_workdir }}:/opt/gcs",
+        "{{ nginx_log_dir }}:/var/log/nginx"
       ]
 
 - name: Check the list of volumes

--- a/ansible/roles/nginx/tasks/virtualhost.yml
+++ b/ansible/roles/nginx/tasks/virtualhost.yml
@@ -14,6 +14,12 @@
     mode: 0750
     recurse: true
 
+- name: Create NGINX log directory
+  file:
+    path: "{{ nginx_log_dir }}"
+    state: directory
+    mode: 0755
+
 - name: "Generate self-signed certificate for {{ instance.fqdn }}"
   shell: "./generate_cert.sh {{ instance.fqdn }}"
   become: false

--- a/ansible/roles/nginx/templates/status.conf.j2
+++ b/ansible/roles/nginx/templates/status.conf.j2
@@ -1,0 +1,13 @@
+server {
+   listen 80;
+   server_name {{ hostvars[groups['nginx'][0]]['ansible_default_ipv4']['address'] }};
+   location /nginx_status {
+       stub_status on;
+       access_log off;
+       allow {{ hostvars[groups['nginx'][0]]['ansible_default_ipv4']['address'] }};
+       deny all;
+   }
+   location / {
+       root /dev/null;
+   }
+}

--- a/ansible/roles/redis/defaults/main.yml
+++ b/ansible/roles/redis/defaults/main.yml
@@ -5,6 +5,9 @@ redis_docker_image: bitnami/redis
 redis_version: latest
 redis_docker_container: redis
 
+redis_workdir: "/docker/redis"
+redis_log_dir: "{{ redis_workdir }}/log"
+
 network:
   bind_host: 0.0.0.0
   publish_host: "{{ ansible_default_ipv4.address }}"

--- a/ansible/roles/redis/files/overrides.conf
+++ b/ansible/roles/redis/files/overrides.conf
@@ -1,0 +1,1 @@
+logfile "/opt/bitnami/redis/logs/redis.log"

--- a/ansible/roles/redis/tasks/main.yml
+++ b/ansible/roles/redis/tasks/main.yml
@@ -1,5 +1,24 @@
 ---
 
+- name: Create redis configuration directory
+  file:
+    path: "{{ redis_workdir }}"
+    state: directory
+    mode: 0750
+    recurse: true
+
+- name: Create redis log directory
+  file:
+    path: "{{ redis_log_dir }}"
+    state: directory
+    mode: 0755
+
+- name: Copy redis overrides.conf
+  copy:
+    src: "{{ role_path }}/files/overrides.conf"
+    dest: "{{ redis_workdir }}/overrides.conf"
+    mode: 0664
+
 - name: Remove old redis container
   docker_container:
     name: "{{ redis_docker_container }}"
@@ -14,5 +33,7 @@
       REDIS_DISABLE_COMMANDS: FLUSHDB,FLUSHALL,CONFIG
     volumes:
       - redis_data:/bitnami/redis/data
+      - "{{ redis_workdir }}/overrides.conf:/opt/bitnami/redis/mounted-etc/overrides.conf"
+      - "{{ redis_log_dir }}:/opt/bitnami/redis/logs/"
     ports:
       - "{{ network.bind_host }}:6379:6379"


### PR DESCRIPTION
This commit adds the monitoring role to customize ops_agent.yaml file for each VM if needed.

For now, there are four types of configurations:
- Docker logs: logging
- MariaDB: logging(docker logs) and metrics
- Redis: logging and metrics
- NGINX: logging and metrics