### PR TITLE
[mordred] Set the correct permissions for the SSH key pair

### DIFF
--- a/ansible/roles/mordred/tasks/configure.yml
+++ b/ansible/roles/mordred/tasks/configure.yml
@@ -70,6 +70,16 @@
     - not sshkey.stat.exists
     - mordred_ssh_key is not defined
 
+- name: Ensure the SSH key pair has the correct permissions
+  file:
+    path: "{{ item.path }}"
+    mode: "{{ item.mode }}"
+  loop:
+    - path: "{{ mordred_ssh_dir }}/id_rsa"
+      mode: '0600'
+    - path: "{{ mordred_ssh_dir }}/id_rsa.pub"
+      mode: '0644'
+
 - name: Set SSH default config for user 'git'
   copy:
     src: "{{ role_path }}/files/ssh_config"


### PR DESCRIPTION
This commit ensures the SSH key pair has the correct permissions.