### PR TITLE
[nginx] Fix NGINX status page

### DIFF
--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
 
-- name: Configure NGINX status page
-  template:
-    src: status.conf.j2
-    dest: "{{ nginx_virtualhosts_workdir }}/status.conf"
-
 - name: Configure virtualhost(s)
   include_tasks: virtualhost.yml
   loop: "{{ nginx_virtualhosts }}"
   loop_control:
     loop_var: instance
+
+- name: Configure NGINX status page
+  template:
+    src: status.conf.j2
+    dest: "{{ nginx_virtualhosts_workdir }}/status.conf"
 
 - name: Configure Google Cloud Storage (GCS)
   include_tasks: gcs.yml


### PR DESCRIPTION
This commit fixes the error `nginx_virtualhosts_workdir` directory does not exist by moving it after the `Configure virtualhost(s)` task (where the directory is created).