### PR TITLE
[terraform] Add custom tags to compute engines on GCP

### DIFF
--- a/docs/provision.md
+++ b/docs/provision.md
@@ -123,6 +123,8 @@ module "bap_env_gcp" {
 
   prefix = "test"
 
+  custom_tags = ["devel", "research"]
+
   mariadb_node_count = 1
   mariadb_machine_type = "e2-standard-2"
 

--- a/terraform/modules/bap_env_gcp/mariadb.tf
+++ b/terraform/modules/bap_env_gcp/mariadb.tf
@@ -4,7 +4,10 @@ module "mariadb" {
   prefix                  = var.prefix
   name                    = "mariadb"
   node_count              = var.mariadb_node_count
-  tags                    = ["identities"]
+  tags                    = flatten([
+                              "identities",
+                              var.custom_tags
+                            ])
   ansible_groups          = ["mariadb"]
 
   machine_type            = var.mariadb_machine_type

--- a/terraform/modules/bap_env_gcp/mordred.tf
+++ b/terraform/modules/bap_env_gcp/mordred.tf
@@ -4,7 +4,10 @@ module "mordred" {
   prefix                  = var.prefix
   name                    = "mordred"
   node_count              = var.mordred_node_count
-  tags                    = ["mordred"]
+  tags                    = flatten([
+                              "mordred",
+                              var.custom_tags
+                            ])
   ansible_groups          = ["mordred"]
 
   machine_type            = var.mordred_machine_type

--- a/terraform/modules/bap_env_gcp/nginx.tf
+++ b/terraform/modules/bap_env_gcp/nginx.tf
@@ -4,7 +4,10 @@ module "nginx" {
   prefix                  = var.prefix
   name                    = "nginx"
   node_count              = var.nginx_node_count
-  tags                    = ["nginx", "http-server", "https-server"]
+  tags                    = flatten([
+                              "nginx", "http-server", "https-server",
+                              var.custom_tags
+                            ])
   ansible_groups          = ["nginx"]
 
   machine_type            = var.nginx_machine_type

--- a/terraform/modules/bap_env_gcp/opensearch.tf
+++ b/terraform/modules/bap_env_gcp/opensearch.tf
@@ -4,7 +4,10 @@ module "opensearch" {
   prefix                  = var.prefix
   name                    = "opensearch"
   node_count              = var.opensearch_node_count
-  tags                    = ["opensearch"]
+  tags                    = flatten([
+                              "opensearch",
+                              var.custom_tags
+                            ])
   ansible_groups          = ["opensearch"]
 
   machine_type            = var.opensearch_machine_type

--- a/terraform/modules/bap_env_gcp/opensearch_dashboard.tf
+++ b/terraform/modules/bap_env_gcp/opensearch_dashboard.tf
@@ -4,7 +4,10 @@ module "opensearch_dashboards" {
   prefix                  = var.prefix
   name                    = "opensearch-dashboards"
   node_count              = var.opensearch_dashboards_node_count
-  tags                    = ["opensearch-dashboards"]
+  tags                    = flatten([
+                              "opensearch-dashboards",
+                              var.custom_tags
+                            ])
   ansible_groups          = ["opensearch-dashboards"]
 
   machine_type            = var.opensearch_dashboards_machine_type

--- a/terraform/modules/bap_env_gcp/opensearch_dashboard_anonymous.tf
+++ b/terraform/modules/bap_env_gcp/opensearch_dashboard_anonymous.tf
@@ -4,7 +4,10 @@ module "opensearch_dashboards_anonymous" {
   prefix                  = var.prefix
   name                    = "opensearch-dashboards-anonymous"
   node_count              = var.opensearch_dashboards_anonymous_node_count
-  tags                    = ["opensearch-dashboards-anonymous"]
+  tags                    = flatten([
+                              "opensearch-dashboards-anonymous",
+                              var.custom_tags
+                            ])
   ansible_groups          = ["opensearch-dashboards-anonymous"]
 
   machine_type            = var.opensearch_dashboards_machine_type

--- a/terraform/modules/bap_env_gcp/redis.tf
+++ b/terraform/modules/bap_env_gcp/redis.tf
@@ -4,7 +4,10 @@ module "redis" {
   prefix                  = var.prefix
   name                    = "redis"
   node_count              = var.redis_node_count
-  tags                    = ["identities"]
+  tags                    = flatten([
+                              "identities",
+                              var.custom_tags
+                            ])
   ansible_groups          = ["redis"]
 
   machine_type            = var.redis_machine_type

--- a/terraform/modules/bap_env_gcp/sortinghat.tf
+++ b/terraform/modules/bap_env_gcp/sortinghat.tf
@@ -4,7 +4,10 @@ module "sortinghat" {
   prefix                  = var.prefix
   name                    = "sortinghat"
   node_count              = var.sortinghat_node_count
-  tags                    = ["sortinghat"]
+  tags                    = flatten([
+                              "sortinghat",
+                              var.custom_tags
+                            ])
   ansible_groups          = ["sortinghat"]
 
   machine_type            = var.sortinghat_machine_type

--- a/terraform/modules/bap_env_gcp/sortinghat_worker.tf
+++ b/terraform/modules/bap_env_gcp/sortinghat_worker.tf
@@ -4,7 +4,10 @@ module "sortinghat_worker" {
   prefix                  = var.prefix
   name                    = "sortinghat-worker"
   node_count              = var.sortinghat_worker_node_count
-  tags                    = ["sortinghat-worker"]
+  tags                    = flatten([
+                              "sortinghat-worker",
+                              var.custom_tags
+                            ])
   ansible_groups          = ["sortinghat-worker"]
 
   machine_type            = var.sortinghat_worker_machine_type

--- a/terraform/modules/bap_env_gcp/variables.tf
+++ b/terraform/modules/bap_env_gcp/variables.tf
@@ -26,6 +26,12 @@ variable "prefix" {
   description = "A prefix to add to the resource name(s), e.g.: '<prefix>-<name>-x'"
 }
 
+variable "custom_tags" {
+  type        = list(any)
+  description = "A list of extra tags for each compute engine"
+  default     = []
+}
+
 # MariaDB
 
 variable "mariadb_node_count" {
@@ -305,4 +311,3 @@ variable "uniform_bucket_level_access" {
   type = bool
   default = false
 }
-


### PR DESCRIPTION
The new variable 'custom_tags' allows to assign new tags to the compute engines in addition to the default ones.