### PR TITLE
[nginx] Open OpenSearch endpoint at "/data"

### DIFF
--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -14,9 +14,11 @@ nginx_log_dir: "{{ nginx_workdir }}/log"
 ##  - fqdn: example.com
 ##    public: false
 ##    tenant: example
+##    http_rest_api: true
 ##  - fqdn: example-public.com
 ##    public: true
 ##    tenant: example-public
+##    http_rest_api: false
 
 # Service hosts
 opensearch_endpoint: "https://{{ hostvars[(groups['opensearch'][0])].ansible_default_ipv4.address }}:9200"
@@ -47,4 +49,3 @@ nginx_keys_workdir: /docker/nginx/keys
 gcloud_apt_deb_ubuntu_repository: >-
   deb [signed-by=/usr/share/keyrings/cloud.google.gpg]
   https://packages.cloud.google.com/apt cloud-sdk main
-

--- a/ansible/roles/nginx/tasks/virtualhost.yml
+++ b/ansible/roles/nginx/tasks/virtualhost.yml
@@ -50,6 +50,14 @@
   loop_control:
     label: "{{ item.dest }}"
 
+- name: "Create load balancer configuration for OpenSearch nodes"
+  run_once: true
+  template:
+    src: "opensearch_nodes.j2"
+    dest: "{{ nginx_virtualhosts_workdir }}/opensearch_nodes.conf"
+    backup: true
+  when: instance.http_rest_api is defined and instance.http_rest_api
+
 - name: "Create virtualhost configuration for {{ instance.fqdn }}"
   template:
     src: "{{ item.template }}"

--- a/ansible/roles/nginx/templates/opensearch_nodes.j2
+++ b/ansible/roles/nginx/templates/opensearch_nodes.j2
@@ -1,0 +1,5 @@
+upstream opensearch_nodes {
+{% for node in groups['opensearch'] %}
+    server {{ hostvars[node].ansible_default_ipv4.address }}:9200;
+{% endfor %}
+}

--- a/ansible/roles/nginx/templates/vhost.j2
+++ b/ansible/roles/nginx/templates/vhost.j2
@@ -46,6 +46,18 @@ server {
         proxy_set_header securitytenant {{ instance.tenant }};
     }
 
+{% if instance.http_rest_api is defined and instance.http_rest_api == true %}
+    location /data/ {
+            proxy_pass https://opensearch_nodes/;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "Keep-Alive";
+            proxy_set_header Proxy-Connection "Keep-Alive";
+            client_max_body_size 2000M;
+            proxy_read_timeout 300;
+            proxy_send_timeout 240;
+    }
+
+{% endif %}
     location /identities {
         rewrite ^/identities/(.*) /$1 break;
 

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -161,9 +161,11 @@ all:
       - fqdn: <fqdn-1>
         public: false
         tenant: <tenant_name_a>
+        http_rest_api: true
       - fqdn: <fqdn-2>
         public: true
         tenant: <tenant_name_b>
+        http_rest_api: false
 ```
 
 Replace the entries in `<>` with your values:
@@ -227,6 +229,8 @@ Replace the entries in `<>` with your values:
   the variable is not defined the OpenSearch Dashboards is private.
 - `nginx_virtualhosts.tenant`: the name of the tenant for this OpenSearch Dashboards endpoint,
   it must be same as `mordred_instances.tenant`.
+- `nginx_virtualhosts.http_rest_api`: Open OpenSearch HTTP rest API only if the variable is defined
+  with the value `true`.
 
 After configuring these parameters, you need to configure the instances of the
 task scheduler (Mordred). You need a task scheduler for each project you want


### PR DESCRIPTION
This commit opens the OpenSearch endpoint at `/data`.