### PR TITLE
All tenant in the same host and activate the tenant selector

### DIFF
--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -9,6 +9,10 @@ nginx_workdir: "/docker/nginx"
 nginx_virtualhosts_workdir: "{{ nginx_workdir }}/conf"
 nginx_log_dir: "{{ nginx_workdir }}/log"
 
+# All instances under the same host and selector tenant enabled.
+# If this is `true` add only one entry in `nginx_virtualhost`.
+bap_single_host: false
+
 # Create your Nginx virtual host configurations
 ## nginx_virtualhosts:
 ##  - fqdn: example.com
@@ -47,4 +51,3 @@ nginx_keys_workdir: /docker/nginx/keys
 gcloud_apt_deb_ubuntu_repository: >-
   deb [signed-by=/usr/share/keyrings/cloud.google.gpg]
   https://packages.cloud.google.com/apt cloud-sdk main
-

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -2,6 +2,7 @@
 
 - name: Configure virtualhost(s)
   include_tasks: virtualhost.yml
+  run_once: "{{ bap_single_host|bool }}"
   loop: "{{ nginx_virtualhosts }}"
   loop_control:
     loop_var: instance

--- a/ansible/roles/nginx/tasks/virtualhost.yml
+++ b/ansible/roles/nginx/tasks/virtualhost.yml
@@ -3,16 +3,26 @@
 - name: Create NGINX virtualhost(s) directory
   file:
     path: "{{ nginx_virtualhosts_workdir }}"
-    state: directory
+    state: "{{ item.state }}"
     mode: 0750
-    recurse: true
+    recurse: "{{ item.recurse }}"
+  with_items:
+    - state: absent
+      recurse: false
+    - state: directory
+      recurse: true
 
 - name: Create certificates directory
   file:
     path: "{{ certs_dir }}"
-    state: directory
+    state: "{{ item.state }}"
     mode: 0750
-    recurse: true
+    recurse: "{{ item.recurse }}"
+  with_items:
+    - state: absent
+      recurse: false
+    - state: directory
+      recurse: true
 
 - name: Create NGINX log directory
   file:

--- a/ansible/roles/nginx/templates/vhost.j2
+++ b/ansible/roles/nginx/templates/vhost.j2
@@ -43,7 +43,9 @@ server {
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
+{% if not bap_single_host|bool %}
         proxy_set_header securitytenant {{ instance.tenant }};
+{% endif %}
     }
 
     location /identities {
@@ -55,7 +57,9 @@ server {
         uwsgi_param X-Real-IP $remote_addr;
         uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
         uwsgi_param X-Forwarded-Proto $http_x_forwarded_proto;
+{% if not bap_single_host|bool %}
         uwsgi_param HTTP_sortinghat-tenant {{ instance.tenant }};
+{% endif %}
     }
 
     location ~ ^/identities/favicon-grimoirelab.ico {

--- a/ansible/roles/opensearch_dashboards/defaults/main.yml
+++ b/ansible/roles/opensearch_dashboards/defaults/main.yml
@@ -63,3 +63,7 @@ opensearch_dashboards_cert_fqdn: opensearch.example.org
 #   base_redirect_url: {{ openid_redirect_url }}
 #   logout_url: "{{ openid_logout_url }}"
 #
+
+# All instances under the same host and selector tenant enabled.
+# If this is `true` add only one entry in `nginx_virtualhost`.
+bap_single_host: false

--- a/ansible/roles/opensearch_dashboards/templates/opensearch_dashboards.yml.j2
+++ b/ansible/roles/opensearch_dashboards/templates/opensearch_dashboards.yml.j2
@@ -60,3 +60,9 @@ opensearch_security.openid.base_redirect_url: "{{ openid.base_redirect_url }}"
 opensearch_security.openid.logout_url: "{{ openid.logout_url }}"
 {% endif %}
 {% endif %}
+
+{% if bap_single_host|bool %}
+bitergia_analytics.hideTenantSelector: false
+{% else %}
+bitergia_analytics.hideTenantSelector: true
+{% endif %}

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -154,6 +154,12 @@ all:
       sources:
         repository: "<repo_teneant_b_projects.git>"
 
+    # All instances under the same host and the selector tenant enabled
+    # on the OpenSearch Dashboards.
+    # If this is `true` add only one entry in `nginx_virtualhost` because
+    # it will use the first one and ignore the rest.
+    bap_single_host: "<bap_single_host>"
+
     # OpenSearch Dashboards Settings for Nginx
     nginx_virtualhosts:
       - fqdn: <fqdn-1>
@@ -224,6 +230,9 @@ Replace the entries in `<>` with your values:
   the variable is not defined the OpenSearch Dashboards is private.
 - `nginx_virtualhosts.tenant`: the name of the tenant for this OpenSearch Dashboards endpoint,
   it must be same as `mordred_instances.tenant`.
+- `bap_single_host`: All instances under the same host and the selector tenant enabled on the
+  OpenSearch Dashboards (by default is `false`). If this is `true` add only one entry in
+  `nginx_virtualhost` because it will use the first one and ignore the rest.
 
 After configuring these parameters, you need to configure the instances of the
 task scheduler (Mordred). You need a task scheduler for each project you want


### PR DESCRIPTION
Add the option to deploy all instances under a single host activating `bap_single_host` (by default is `false`). This will enable the tenant selector on the OpenSearch Dashboards UI.

If this is deactivated it will deploy each instance to a different host.