### PR TITLE
[terraform] Add "storage-ro" service account scope to Nginx VM

### DIFF
--- a/terraform/modules/bap_env_gcp/nginx.tf
+++ b/terraform/modules/bap_env_gcp/nginx.tf
@@ -20,6 +20,8 @@ module "nginx" {
   subnetwork              = var.subnetwork
   enable_external_ip      = true
   ansible_use_external_ip = var.nginx_ansible_use_external_ip
+
+  service_account_extra_scopes  = ["storage-ro"]
 }
 
 output "nginx" {

--- a/terraform/modules/bap_gcp_instance/main.tf
+++ b/terraform/modules/bap_gcp_instance/main.tf
@@ -60,6 +60,10 @@ resource "google_compute_instance" "bap" {
   }
 
   service_account {
-    scopes = var.service_account_scopes
+    scopes = flatten([
+      "logging-write",
+      "monitoring-write",
+      var.service_account_extra_scopes
+    ])
   }
 }

--- a/terraform/modules/bap_gcp_instance/variables.tf
+++ b/terraform/modules/bap_gcp_instance/variables.tf
@@ -69,13 +69,10 @@ variable "enable_external_ip" {
   default     = false
 }
 
-variable "service_account_scopes" {
+variable "service_account_extra_scopes" {
   type        = list(string)
-  description = "List of Service Account scopes to apply to the instances"
-  default = [
-    "logging-write",
-    "monitoring-write"
-  ]
+  description = "List of Service Account extra scopes to apply to the instances"
+  default = []
 }
 
 variable "ansible_use_external_ip" {


### PR DESCRIPTION
This commit adds `storage-ro` service account scope to Nginx to download the SortingHat static files from a Google Cloud Store Bucket.