### PR TITLE
[mariadb] Add wait_timeout parameter

### DIFF
--- a/ansible/roles/mariadb/defaults/main.yml
+++ b/ansible/roles/mariadb/defaults/main.yml
@@ -8,6 +8,10 @@ python_packages:
 mariadb_docker_image: mariadb
 mariadb_version: latest
 
+# Number of seconds the server waits for activity of a non-interactive
+# connection before closing it. The default value is 28800 seconds (8 hours).
+mariadb_wait_timeout: 28800
+
 mariadb_workdir: "/docker/mariadb"
 gcp_service_account_file: "{{ mariadb_workdir }}/gcs_credentials.json"
 

--- a/ansible/roles/mariadb/tasks/main.yml
+++ b/ansible/roles/mariadb/tasks/main.yml
@@ -22,7 +22,7 @@
   docker_container:
     name: mariadb
     image: "{{ mariadb_docker_image }}:{{ mariadb_version }}"
-    command: --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: --wait_timeout={{ mariadb_wait_timeout }} --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
     pull: true
     restart_policy: always
     state: started


### PR DESCRIPTION
This parameter allows to set the number of seconds a connection can be active in MariaDB. Useful to increase when there are for long processes in BAP such as unification or affiliation of individuals.