### PR TITLE
[mariadb] Create MariaDB backups per database

### DIFF
--- a/ansible/roles/mariadb/tasks/main.yml
+++ b/ansible/roles/mariadb/tasks/main.yml
@@ -67,6 +67,20 @@
   tags:
     - test
 
+- name: Create backup service account with the minimum required permissions
+  mysql_user:
+    name: "{{ mariadb_backup_service_account }}"
+    host: "{{ ansible_default_ipv4.address }}"
+    password: "{{ mariadb_backup_service_account_password }}"
+    priv: '*.*:SELECT,SHOW VIEW,TRIGGER,LOCK TABLES,GRANT'
+    login_user: root
+    login_password: "{{ mariadb_root_password }}"
+    state: present
+  register: result
+  retries: 2
+  delay: 5
+  until: result is success
+
 - name: Copy MariaDB backup script
   template:
     src: mariadb_backup.sh.j2

--- a/ansible/roles/mariadb/templates/mariadb_backup.sh.j2
+++ b/ansible/roles/mariadb/templates/mariadb_backup.sh.j2
@@ -1,12 +1,29 @@
 #!/bin/bash
 
-DUMP_FOLDER="/tmp"
+USER={{ mariadb_backup_service_account }}
+PASSWORD="{{ mariadb_backup_service_account_password }}"
+HOST={{ groups['mariadb'][0] }}
 
+DUMP_FOLDER="/tmp"
 DATE=$(date "+%Y%m%d")
 
-filename="mariadb_${DATE}.sql"
-output_file="${DUMP_FOLDER}/${filename}"
+DATABASES=`mysql --user=$USER --password=$PASSWORD --host=$HOST -se "show databases;"`
+BLACK_LIST="Database performance_schema information_schema"
 
-mysqldump --user=root --password={{ mariadb_root_password }} --host={{ groups['mariadb'][0] }} --all-databases > "$output_file"
-gsutil cp "$output_file" "gs://{{ backups_assets_bucket }}/${filename}"
-rm "${output_file}"
+list_not_include_item () {
+  local item=$1
+  [[ "$BLACK_LIST" =~ (^|[[:space:]])"$item"($|[[:space:]]) ]] && result=1 || result=0
+  return $result
+}
+
+for database in $DATABASES
+do
+    if list_not_include_item $database
+    then
+       filename="${database}_${DATE}.sql"
+       output_file="${DUMP_FOLDER}/${filename}"
+       mysqldump --user=$USER --password=$PASSWORD --host=$HOST $database > "$output_file"
+       gsutil cp "$output_file" "gs://{{ backups_assets_bucket }}/mariadb/${filename}"
+       rm "${output_file}"
+    fi
+done

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -94,6 +94,8 @@ all:
 
     # Passwords and credentials
     mariadb_root_password: <mariadb_root_password>
+    mariadb_backup_service_account: backup
+    mariadb_backup_service_account_password: <mariadb_backup_password>
     mariadb_service_account: sortinghat
     mariadb_service_account_password: <sortinghat_password>
     redis_password: <redis_password>
@@ -175,6 +177,7 @@ Replace the entries in `<>` with your values:
   in a `.json` file under the `keys/<environment>/` directory.
 - `project_id`: the [id](https://support.google.com/googleapi/answer/7014113?hl=en) of the GCP project.
 - `mariadb_root_password`: strong password for the MariaDB root user.
+- `mariadb_backup_service_account_password`: strong password for the MariaDB backup service account.
 - `mariadb_service_account_password`: strong password for the MariaDB
   service account user.
 - `redis_password`: strong password for the redis server.


### PR DESCRIPTION
This code creates a backup service account with the minimum required permissions to create backups. Also, it creates a backup for each database in MariaDB.

Fixes #46