### PR TITLE
[mariadb] Improve performance using `innodb_buffer_pool_size`

### DIFF
--- a/ansible/roles/mariadb/defaults/main.yml
+++ b/ansible/roles/mariadb/defaults/main.yml
@@ -37,3 +37,7 @@ mariadb_backup_cronjob_time:
   minute: "0"
   weekday: "0"
 mariadb_backup_script: /usr/local/bin/mariadb_backup.sh
+
+# Improve MariaDB performance. A good value is 70%-80% of available memory.
+# By default it use e2-standard-2 8G of memory. 6.4G is the 80% of 8G -> 6871947673
+mariadb_innodb_buffer_pool_size: 6871947673

--- a/ansible/roles/mariadb/tasks/main.yml
+++ b/ansible/roles/mariadb/tasks/main.yml
@@ -22,7 +22,7 @@
   docker_container:
     name: mariadb
     image: "{{ mariadb_docker_image }}:{{ mariadb_version }}"
-    command: --wait_timeout={{ mariadb_wait_timeout }} --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: "--wait_timeout={{ mariadb_wait_timeout }} --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --innodb_buffer_pool_size={{ mariadb_innodb_buffer_pool_size }}"
     pull: true
     restart_policy: always
     state: started

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -100,6 +100,9 @@ all:
     mariadb_service_account_password: <sortinghat_password>
     redis_password: <redis_password>
 
+    # MariaDB Settings
+    mariadb_innodb_buffer_pool_size: <innodb_buffer_pool_size>
+
     # OpenSearch Settings
     opensearch_cluster_prefix: <opensearch_cluster_prefix>
     opensearch_cluster_name: <opensearch_cluster_name>
@@ -183,6 +186,9 @@ Replace the entries in `<>` with your values:
 - `mariadb_service_account_password`: strong password for the MariaDB
   service account user.
 - `redis_password`: strong password for the redis server.
+- `mariadb_innodb_buffer_pool_size`: The size in bytes of the buffer pool, the memory
+  area where InnoDB caches table and index data. A good value is 70%-80% of available
+  memory (by default is `6871947673` 6.4G)
 - `opensearch_cluster_prefix`: prefix of the OpenSearch cluster.
 - `opensearch_cluster_name` (optional): name of the OpenSearch cluster.
   This value will be used in combination with `<opensearch_cluster_prefix>`


### PR DESCRIPTION
Add the `innodb_buffer_pool_size` parameter to improve the MariaDB performance in the docker command. A good value is 70%-80% of available memory.

docs/deployment_and_config.md updated accordingly.