### PR TITLE
[terraform] Add GCP IAP tunnel

### DIFF
--- a/ansible/roles/nginx/templates/vhost.j2
+++ b/ansible/roles/nginx/templates/vhost.j2
@@ -29,7 +29,7 @@ server {
     ssl_session_timeout 10m;
     add_header Strict-Transport-Security "max-age=63072000;" always;
 
-    rewrite ^/$ /app/dashboards#/view/Overview permanent;
+    rewrite ^/$ $scheme://$http_host/app/dashboards#/view/Overview permanent;
     location / {
 {% if instance.public is defined and instance.public == true %}
         proxy_pass https://{{ hostvars[(groups['opensearch_dashboards_anonymous'][0])].ansible_default_ipv4.address }}:5601/;

--- a/ansible/roles/sortinghat/defaults/main.yml
+++ b/ansible/roles/sortinghat/defaults/main.yml
@@ -42,8 +42,8 @@ redis_hosts: "{{ groups['redis'] | first }}"
 sortinghat_debug: "false"
 
 # CSRF and CORS configuration
-sortinghat_allowed_hosts: "{{ groups['sortinghat'][0] }},{{ groups['mordred'][0] }}"
-sortinghat_cors_allowed_origins: "https://{{ groups['sortinghat'][0] }},https://{{ groups['mordred'][0] }}"
+sortinghat_allowed_hosts: "localhost,{{ groups['sortinghat'][0] }},{{ groups['mordred'][0] }}"
+sortinghat_cors_allowed_origins: "https://localhost,https://{{ groups['sortinghat'][0] }},https://{{ groups['mordred'][0] }}"
 
 # NGINX
 

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -363,33 +363,46 @@ ansible-playbook -i environments/<environment>/inventory/ playbooks/all.yml
 After some minutes, the platform will be accessible in the domain you configured
 on the previous step.
 
-### IAP tunnel (Opcional)
+### Connection to the platform using a IAP tunnel (GCP only)
 
-Only if IAP tunnel is activated (`network_iap_tunnel = true`).
+If you configured an IAP tunnel to secure the access of the platform, you will
+have to run some commands in your computer, in order to connect to front-end.
+This configuration requires to have installed [gcloud CLI](https://cloud.google.com/sdk/docs/install).
 
-- Check if the project is already configured.
+First, you will need to check if the GCP project where you installed
+the platform is active in your local configuration.
+
 ```terminal
 gcloud config configurations list
 gcloud config configurations activate [NAME]
 ```
 
-- Configure it if it is not.
+If it's not, you will have to set it as active.
+
 ```terminal
 gcloud config configurations create [NAME]
 gcloud config set project [PROJECT-ID]
 gcloud auth login
 ```
 
-- Tunneling other TCP connections, more info at https://cloud.google.com/iap/docs/using-tcp-forwarding
+Once the project is configured in your local machine, you will need to create
+a tunnel for your TCP connections. This tunnel goes from your local machine
+to the to the NGINX instance, where the front-end is served.
+
 ```terminal
 gcloud compute start-iap-tunnel <NGINX_INSTANCE_NAME> 443 --local-host-port=localhost:<LOCAL_PORT> --zone=<ZONE>
 ```
 
-- Open your browser with `https://localhost:<LOCAL_PORT>`
+Then, connect to the dashboard with your browser
+with the URL `https://localhost:<LOCAL_PORT>`.
 
-For example:
+For example, to connect to the dashboard using the port `8443` of your local
+machine, you will have to run the following command:
+
 ```terminal
 gcloud compute start-iap-tunnel test-nginx-0 443 --local-host-port=localhost:8443 --zone=europe-southwest1-a
 ```
 
-Open your browser with https://localhost:8443
+Then, open your browser with the URL `https://localhost:8443`.
+
+You can also find more info about TCP tunnels on [this doc](https://cloud.google.com/iap/docs/using-tcp-forwarding).

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -362,3 +362,34 @@ ansible-playbook -i environments/<environment>/inventory/ playbooks/all.yml
 
 After some minutes, the platform will be accessible in the domain you configured
 on the previous step.
+
+### IAP tunnel (Opcional)
+
+Only if IAP tunnel is activated (`network_iap_tunnel = true`).
+
+- Check if the project is already configured.
+```terminal
+gcloud config configurations list
+gcloud config configurations activate [NAME]
+```
+
+- Configure it if it is not.
+```terminal
+gcloud config configurations create [NAME]
+gcloud config set project [PROJECT-ID]
+gcloud auth login
+```
+
+- Tunneling other TCP connections, more info at https://cloud.google.com/iap/docs/using-tcp-forwarding
+```terminal
+gcloud compute start-iap-tunnel <NGINX_INSTANCE_NAME> 443 --local-host-port=localhost:<LOCAL_PORT> --zone=<ZONE>
+```
+
+- Open your browser with `https://localhost:<LOCAL_PORT>`
+
+For example:
+```terminal
+gcloud compute start-iap-tunnel test-nginx-0 443 --local-host-port=localhost:8443 --zone=europe-southwest1-a
+```
+
+Open your browser with https://localhost:8443

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -30,7 +30,6 @@ to some service accounts. These are the APIs to enable:
 - `compute.googleapis.com`
 - `iam.googleapis.com`
 - `cloudresourcemanager.googleapis.com`
-- `iap.googleapis.com` (**Note**: Only if you want to activate IAP tunnel)
 
 By default, the services above aren't activated when a GCP project is created,
 but they might be already activated on your project if it's been used for other
@@ -43,12 +42,6 @@ commands:
 gcloud services enable compute.googleapis.com
 gcloud services enable iam.googleapis.com
 gcloud services enable cloudresourcemanager.googleapis.com
-```
-
-Activate IAP service (Optional)
-
-```terminal
-gcloud services enable iap.googleapis.com
 ```
 
 The services should now been activated.
@@ -66,7 +59,6 @@ for these tasks. To create one, follow these steps:
    - `Compute Admin`
    - `Storage Admin` (**Note**: not `Compute Storage Admin`)
    - `Service Account User`
-   - `IAP Policy Admin` (**Note**: Only if you want to activate IAP tunnel)
 
 Once the account has been created, you will need to create a key file:
 
@@ -222,6 +214,41 @@ client ID.
      - `https://<domain>/` (e.g. `https://myproject.example.com`)
      - `https://<domain>/auth/openid/login` (e.g. `https://myproject.example.com/auth/openid/login`)
 1. Click on `CREATE` and save JSON file with the credentials for later usage.
+
+#### Setup IAP (Optional)
+
+IAP allows to _establish a central authorization layer for applications
+accessed by HTTPS_. You can define which users or groups in your organization
+can access which resources.
+[Google documentation](https://cloud.google.com/iap/docs/concepts-overview)
+provides a extensive description of how IAP works and how you can configure
+to limit the access to your resources.
+
+If you want to restrict the access to BAP, using IAP, for users or groups
+within your GCP organization, you will have to give some permissions
+to the project. IAP requires of:
+
+- `iap.googleapis.com` (service)
+- `IAP Policy Admin` (IAM policy)
+
+Activate the service from the Cloud Shell terminal with:
+
+```terminal
+gcloud services enable iap.googleapis.com
+```
+
+And assign the policy to the service account created in the previous steps:
+
+1. Access GCP's [IAM permissions](https://console.cloud.google.com/iam-admin/iam) page.
+1. Select the correct project in the dropdown at the top of the page.
+1. Click on the pencil icon of the BAP service account created for this project.
+1. Click on `+ ADD ANOTHER ROLE`.
+1. Select the role `IAP Policy Admin`.
+1. Click on `SAVE`.
+
+On the next sections, you will be able to create a IAP tunnel through TCP,
+so the front-end of the platform will only be accessible selected users
+from their local computers.
 
 ## 2. Setup the Control Node
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -30,6 +30,7 @@ to some service accounts. These are the APIs to enable:
 - `compute.googleapis.com`
 - `iam.googleapis.com`
 - `cloudresourcemanager.googleapis.com`
+- `iap.googleapis.com` (**Note**: Only if you want to activate IAP tunnel)
 
 By default, the services above aren't activated when a GCP project is created,
 but they might be already activated on your project if it's been used for other
@@ -42,6 +43,12 @@ commands:
 gcloud services enable compute.googleapis.com
 gcloud services enable iam.googleapis.com
 gcloud services enable cloudresourcemanager.googleapis.com
+```
+
+Activate IAP service (Optional)
+
+```terminal
+gcloud services enable iap.googleapis.com
 ```
 
 The services should now been activated.
@@ -59,6 +66,7 @@ for these tasks. To create one, follow these steps:
    - `Compute Admin`
    - `Storage Admin` (**Note**: not `Compute Storage Admin`)
    - `Service Account User`
+   - `IAP Policy Admin` (**Note**: Only if you want to activate IAP tunnel)
 
 Once the account has been created, you will need to create a key file:
 

--- a/docs/provision.md
+++ b/docs/provision.md
@@ -117,11 +117,16 @@ We have three scenarios for OpenSearch Dashboards:
 Ansible will provision the OpenSearch Dashboard machines depending on which
 group the hostname belongs to.
 
+You can activate IAP tunnel:
+  - `network_iap_tunnel = true`
+  - `network_nginx_iap_tunnel_members = ["user:example@example.com"]` (More info about [members](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iap_tunnel_instance_iam#argument-reference))
+
 ```tf
 module "bap_env_gcp" {
   source = "../../modules/bap_env_gcp"
 
   prefix = "test"
+  zone = var.zone
 
   custom_tags = ["devel", "research"]
 
@@ -149,6 +154,9 @@ module "bap_env_gcp" {
 
   sortinghat_worker_node_count = 2
   sortinghat_worker_machine_type = "e2-standard-2"
+
+  network_iap_tunnel = false
+  network_nginx_iap_tunnel_members = ["user:example@example.com"]
 }
 
 output "bap_env_gcp" {

--- a/docs/provision.md
+++ b/docs/provision.md
@@ -117,9 +117,16 @@ We have three scenarios for OpenSearch Dashboards:
 Ansible will provision the OpenSearch Dashboard machines depending on which
 group the hostname belongs to.
 
-You can activate IAP tunnel:
-  - `network_iap_tunnel = true`
-  - `network_nginx_iap_tunnel_members = ["user:example@example.com"]` (More info about [members](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iap_tunnel_instance_iam#argument-reference))
+If you decided to activate IAP, you can also create a TCP tunnel, so the
+platform will only be accessible to the defined users through it. There won't
+be any other way to access it. You can activate this IAP tunnel over TCP with
+the following config parameters. By default, the tunnel won't be created.
+
+- `network_iap_tunnel = true`
+- `network_nginx_iap_tunnel_members = ["user:example@example.com"]`
+
+If you have doubts about how to list the users, please check the following
+[link](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iap_tunnel_instance_iam#argument-reference).
 
 ```tf
 module "bap_env_gcp" {

--- a/terraform/modules/bap_env_gcp/network.tf
+++ b/terraform/modules/bap_env_gcp/network.tf
@@ -26,8 +26,8 @@ resource "google_compute_firewall" "fw-nginx" {
     ports    = ["80", "443"]
   }
 
-source_ranges = ["0.0.0.0/0"]
-target_tags = ["nginx", "http-server", "https-server"]
+  source_ranges = var.network_fw_nginx_source_ranges
+  target_tags = ["nginx", "http-server", "https-server"]
 }
 
 # resource "google_compute_firewall" "deny-ssh" {
@@ -54,7 +54,7 @@ resource "google_compute_firewall" "allow-ssh" {
     ports    = ["22"]
   }
 
-source_ranges = ["35.235.240.0/20", "10.0.0.0/8"]
+  source_ranges = ["10.0.0.0/8"]
 }
 
 resource "google_compute_firewall" "allow-services" {
@@ -66,5 +66,17 @@ resource "google_compute_firewall" "allow-services" {
     ports    = ["3306","5601","9200","9300","9600"]
   }
 
-source_ranges = ["35.235.240.0/20", "10.0.0.0/8"]
+  source_ranges = ["10.0.0.0/8"]
+}
+
+resource "google_iap_tunnel_instance_iam_binding" "nginx-iap-https-policy" {
+  count = var.network_iap_tunnel ? 1 : 0
+  instance = split("/instances/", module.nginx.machine_id[0])[1]
+  role     = "roles/iap.tunnelResourceAccessor"
+  members = var.network_nginx_iap_tunnel_members
+
+  condition {
+    title      = "port 443 only"
+    expression = "destination.port == 443"
+  }
 }

--- a/terraform/modules/bap_env_gcp/nginx.tf
+++ b/terraform/modules/bap_env_gcp/nginx.tf
@@ -18,7 +18,7 @@ module "nginx" {
 
   network                 = var.network
   subnetwork              = var.subnetwork
-  enable_external_ip      = true
+  enable_external_ip      = var.nginx_enable_external_ip
   ansible_use_external_ip = var.nginx_ansible_use_external_ip
 
   service_account_extra_scopes  = ["storage-ro"]

--- a/terraform/modules/bap_env_gcp/variables.tf
+++ b/terraform/modules/bap_env_gcp/variables.tf
@@ -194,6 +194,11 @@ variable "nginx_disk_type" {
   default = "pd-standard"
 }
 
+variable "nginx_enable_external_ip" {
+  type    = bool
+  default = true
+}
+
 variable "nginx_ansible_use_external_ip" {
   type    = bool
   default = false
@@ -310,4 +315,24 @@ variable "sortinghat_storage_location" {
 variable "uniform_bucket_level_access" {
   type = bool
   default = false
+}
+
+# Network
+
+variable "network_fw_nginx_source_ranges" {
+  type = list(any)
+  description = "A list of source ranges"
+  default     = ["0.0.0.0/0"]
+}
+
+variable "network_nginx_iap_tunnel_members" {
+  type = list(any)
+  description = "A list of IAP members, e.g.: ['user:example@example.com', 'group:dev@example.com']"
+  default     = []
+}
+
+variable "network_iap_tunnel" {
+  type        = bool
+  description = "Activate IAP tunnel"
+  default     = false
 }


### PR DESCRIPTION
Option to active GCP IAP tunnel by setting the `network_iap_tunnel = true` in the environment TF file.

Solves #51 