### PR TITLE
[sortinghat] Fix tenant name

### DIFF
--- a/ansible/roles/nginx/templates/vhost.j2
+++ b/ansible/roles/nginx/templates/vhost.j2
@@ -67,7 +67,7 @@ server {
         uwsgi_param X-Real-IP $remote_addr;
         uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
         uwsgi_param X-Forwarded-Proto $http_x_forwarded_proto;
-        uwsgi_param HTTP_sortinghat-tenant {{ instance.tenant }};
+        uwsgi_param HTTP_sortinghat-tenant {{ instance.tenant | replace('-','_') }};
     }
 
     location ~ ^/identities/favicon-grimoirelab.ico {

--- a/ansible/roles/sortinghat/tasks/main.yml
+++ b/ansible/roles/sortinghat/tasks/main.yml
@@ -5,9 +5,9 @@
     priviledges: |-
       {
       {% for item in nginx_virtualhosts %}
-        "{{ item.tenant }}.*":"ALL,GRANT",
+        "{{ item.tenant | replace('-','_') }}.*":"ALL,GRANT",
       {% endfor %}
-        "{{ sortinghat_database }}.*":"ALL,GRANT"
+        "{{ sortinghat_database | replace('-','_') }}.*":"ALL,GRANT"
       }
 
 - name: Check priviledges list
@@ -52,7 +52,7 @@
         "tenants": [
           {% for item in nginx_virtualhosts %}
             {{ "" if loop.first else "," }}
-            "{{ item.tenant }}"
+            "{{ item.tenant | replace('-','_') }}"
           {% endfor %}
         ]
       }
@@ -85,7 +85,7 @@
       SORTINGHAT_DB_HOST: "{{ mariadb_hosts }}"
       SORTINGHAT_DB_USER: "{{ mariadb_service_account }}"
       SORTINGHAT_DB_PASSWORD: "{{ mariadb_service_account_password }}"
-      SORTINGHAT_DB_DATABASE: "{{ sortinghat_database }}"
+      SORTINGHAT_DB_DATABASE: "{{ sortinghat_database | replace('-','_') }}"
       SORTINGHAT_REDIS_HOST: "{{ redis_hosts }}"
       SORTINGHAT_REDIS_PASSWORD: "{{ redis_password }}"
       SORTINGHAT_REDIS_DB: "{{ redis_database }}"
@@ -108,7 +108,7 @@
 
 - name: "Add {{ sortinghat_superuser_name }} user to all tenants for {{ ansible_hostname }}"
   command: >
-    docker exec {{ sortinghat_docker_container }} /opt/venv/bin/sortinghat-admin set-user-tenant {{ sortinghat_superuser_name }} {{ item.tenant }} {{ item.tenant }}
+    docker exec {{ sortinghat_docker_container }} /opt/venv/bin/sortinghat-admin set-user-tenant {{ sortinghat_superuser_name }} {{ item.tenant | replace('-','_') }} {{ item.tenant | replace('-','_') }}
   loop: "{{ nginx_virtualhosts }}"
   when: sortinghat_multi_tenant is defined and sortinghat_multi_tenant == "true"
 

--- a/ansible/roles/sortinghat_worker/tasks/main.yml
+++ b/ansible/roles/sortinghat_worker/tasks/main.yml
@@ -5,9 +5,9 @@
     priviledges: |-
       {
       {% for item in nginx_virtualhosts %}
-        "{{ item.tenant }}.*":"ALL,GRANT",
+        "{{ item.tenant | replace('-','_') }}.*":"ALL,GRANT",
       {% endfor %}
-        "{{ sortinghat_database }}.*":"ALL,GRANT"
+        "{{ sortinghat_database | replace('-','_') }}.*":"ALL,GRANT"
       }
 
 - name: Check priviledges list
@@ -69,7 +69,7 @@
       SORTINGHAT_DB_HOST: "{{ mariadb_hosts }}"
       SORTINGHAT_DB_USER: "{{ mariadb_service_account }}"
       SORTINGHAT_DB_PASSWORD: "{{ mariadb_service_account_password }}"
-      SORTINGHAT_DB_DATABASE: "{{ sortinghat_database }}"
+      SORTINGHAT_DB_DATABASE: "{{ sortinghat_database | replace('-','_') }}"
       SORTINGHAT_REDIS_HOST: "{{ redis_hosts }}"
       SORTINGHAT_REDIS_PASSWORD: "{{ redis_password }}"
       SORTINGHAT_REDIS_DB: "{{ redis_database }}"


### PR DESCRIPTION
This code replaces the `-` character with `_` because in MariaDB the `-` character is not valid for the database name.