### PR TITLE
Bump BAP version to 0.14.1

### DIFF
--- a/ansible/roles/mordred/defaults/main.yml
+++ b/ansible/roles/mordred/defaults/main.yml
@@ -2,7 +2,7 @@
 
 # Bitergia Analytics image and container
 bap_docker_image: bitergia/bitergia-analytics
-bap_version: 0.14.0
+bap_version: 0.14.1
 
 # GrimoireLab configuration
 mordred_workdir: "/docker/mordred"

--- a/ansible/roles/sortinghat/defaults/main.yml
+++ b/ansible/roles/sortinghat/defaults/main.yml
@@ -2,7 +2,7 @@
 
 # SortingHat image and container
 sortinghat_docker_image: bitergia/bitergia-analytics-sortinghat
-sortinghat_version: 0.14.0
+sortinghat_version: 0.14.1
 sortinghat_docker_container: bap_sortinghat
 
 # SortingHat node configuration

--- a/ansible/roles/sortinghat_worker/defaults/main.yml
+++ b/ansible/roles/sortinghat_worker/defaults/main.yml
@@ -5,7 +5,7 @@ sortinghat_worker_workdir: "/docker/sortinghat_worker"
 
 # SortingHat image and container
 sortinghat_worker_docker_image: bitergia/bitergia-analytics-sortinghat-worker
-sortinghat_worker_version: 0.14.0
+sortinghat_worker_version: 0.14.1
 sortinghat_worker_docker_container: bap_sortinghat_worker
 sortinghat_workers: 1
 


### PR DESCRIPTION
This commit updates the version of BAP to 0.14.1 deployed with the toolkit.