### PR TITLE
[mordred] Add support for multiple Mordred hosts

### DIFF
--- a/ansible/roles/mordred/defaults/main.yml
+++ b/ansible/roles/mordred/defaults/main.yml
@@ -26,11 +26,13 @@ mordred_aliases_url: https://raw.githubusercontent.com/chaoss/grimoirelab-sirmor
 ##   - password: "<PASSWORD>"
 ##     overwrite_roles: true
 ##     sources_repository: "<PROJECT1_SOURCE_REPO_URL>"
+##     host: 0
 ## - project: project2
 ##   tenant: project2
 ##   mordred:
 ##   - password: "<PASSWORD>"
 ##     overwrite_roles: true
 ##     sources_repository: "<PROJECT2_SOURCE_REPO_URL>"
+##     host: 1
 
 mariadb_hosts: "{{ groups['mariadb'] }}"

--- a/ansible/roles/mordred/tasks/configure.yml
+++ b/ansible/roles/mordred/tasks/configure.yml
@@ -102,6 +102,11 @@
     loop_var: instance
     label: "{{ instance.project }}"
 
+- name: Create ~/.gitconfig setting with safe directories
+  template:
+    src: gitconfig.j2
+    dest: ~/.gitconfig
+
 - name: Checkout mordred setups repo
   become: true
   become_user: grimoire

--- a/ansible/roles/mordred/tasks/configure_instance.yml
+++ b/ansible/roles/mordred/tasks/configure_instance.yml
@@ -1,10 +1,12 @@
 ---
 
-- name: Set instance variables
+- name: "Set {{ instance.project }} instance variables"
   set_fact:
     instance_dir: "{{ mordred_instances_dir }}/{{ instance.project }}"
+  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  run_once: true
 
-- name: Ensure instance directories are created
+- name: "Ensure {{ instance.project }} instance directories are created"
   file:
     state: directory
     path: "{{ item }}"
@@ -16,24 +18,29 @@
     - "{{ instance_dir }}/logs"
     - "{{ instance_dir }}/sources"
     - "{{ instance_dir }}/perceval-cache"
+  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  run_once: true
 
-- name: Add tenant to aliases.json file
+- name: "Add {{ instance.tenant }} tenant to aliases.json file"
   become: false
   command: >-
       python3 {{ role_path }}/files/add_tenant_aliases.py
       {{ upstream_aliases.dest }} {{ instance.tenant }} -o /tmp/{{ instance.tenant }}_aliases.json
   delegate_to: localhost
   changed_when: false
+  run_once: true
 
-- name: Copy aliases.json
+- name: "Copy {{ instance.tenant }} aliases.json"
   copy:
     src: "/tmp/{{ instance.tenant }}_aliases.json"
     dest: "{{ instance_dir }}/conf/aliases.json"
     owner: grimoire
     group: grimoire
     mode: '0640'
+  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  run_once: true
 
-- name: Checkout sources repo
+- name: "Checkout {{ instance.project }} sources repo"
   become: true
   become_user: grimoire
   git:
@@ -41,20 +48,26 @@
     dest: "{{ instance_dir }}/sources"
     force: true
   when: instance.mordred.sources_repository is defined
+  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  run_once: true
 
-- name: Change sources permissions
+- name: "Change {{ instance.project }} sources permissions"
   file:
     state: directory
     path: "{{ instance_dir }}/sources"
     owner: grimoire
     group: grimoire
     mode: '0774'
+  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  run_once: true
 
 - name: "Create cron job to pull changes from {{ instance.project }} sources repo"
   cron:
     name: "Pull {{ instance.project }} sources"
     user: "{{ ansible_user_id }}"
     job: "cd {{ instance_dir }}/sources && git pull"
+  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  run_once: true
 
 - name: "Create MariaDB service account for {{ instance.project }}"
   mysql_user:
@@ -72,14 +85,20 @@
   until: result is success
   with_items:
     - "{{ mariadb_hosts }}"
+  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  run_once: true
 
 - name: Set anonymous role if opensearch_dashboards_anonymous is defined and the instance is public
   set_fact:
     anonymous: "{% if 'opensearch_dashboards_anonymous' in groups and groups['opensearch_dashboards_anonymous'] and 'instance.public' %} -a {% else %} {% endif %}"
+  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  run_once: true
 
 - name: Add --force option (create_roles_tenat.py) if overwrite_roles is defined and the value is true
   set_fact:
     overwrite_roles: "{% if instance.overwrite_roles is defined and instance.overwrite_roles %} --force {% else %} {% endif %}"
+  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  run_once: true
 
 - name: "Create roles and tenant for {{ instance.project }}"
   become: false
@@ -88,6 +107,7 @@
     https://{{ opensearch_admin_user }}:{{ opensearch_admin_password }}@{{ groups['opensearch'][0] }}:9200 {{ instance.tenant }} {{ anonymous }}
     {{ overwrite_roles }}
   delegate_to: localhost
+  run_once: true
 
 - name: "Create mordred user for {{ instance.project }}"
   uri:
@@ -107,3 +127,5 @@
   retries: 10
   delay: 2
   become: false
+  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  run_once: true

--- a/ansible/roles/mordred/tasks/main.yml
+++ b/ansible/roles/mordred/tasks/main.yml
@@ -22,6 +22,8 @@
     state: absent
   with_items:
     - "{{ instances }}"
+  delegate_to: "{{ groups['mordred'][item.mordred.host] }}"
+  run_once: true
 
 - name: docker
   docker_container:
@@ -36,3 +38,5 @@
     - "{{ mordred_instances_dir }}/{{ item.project }}/perceval-cache/:/home/grimoire/.perceval/"
   with_items:
     - "{{ instances }}"
+  delegate_to: "{{ groups['mordred'][item.mordred.host] }}"
+  run_once: true

--- a/ansible/roles/mordred/templates/gitconfig.j2
+++ b/ansible/roles/mordred/templates/gitconfig.j2
@@ -1,0 +1,4 @@
+[safe]
+{% for instance in instances %}
+    directory = {{ mordred_instances_dir }}/{{ instance.project }}/sources
+{% endfor %}

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -156,6 +156,7 @@ all:
         password: <mordred_tenant_a_password>
         overwrite_roles: <overwrite_roles>
         sources_repository: "<repo_teneant_a_projects.git>"
+        host: <mordred_host_a>
       nginx:
         fqdn: <fqdn-1>
         http_rest_api: false
@@ -166,6 +167,7 @@ all:
         password: <mordred_tenant_b_password>
         overwrite_roles: <overwrite_roles>
         sources_repository: "<repo_teneant_b_projects.git>"
+        host: <mordred_host_b>
       nginx:
         fqdn: <fqdn-2>
         sortinghat_tenant: <sortinghat_tenant>
@@ -247,6 +249,7 @@ about how to setup the task scheduler.
    of this tenant.
 - `instances.mordred.sources_repository`: repository with the list of data
    sources to analyze on this project.
+- `instances.mordred.host`: on which mordred VM host will deploy the container (e.g. `0`).
 - `instances.nginx.fqdn`: full qualified domain name (e.g. `bap.example.com`)
   where BAP will be available.
 - `instances.nginx.tenant` (optional): the name used here will be used to store the data from


### PR DESCRIPTION
This commit adds support for multiple Mordred hosts. This allows us to choose which host the Mordreds are deployed on.