### PR TITLE
[sortinghat] Fix 'Create databases' job

### DIFF
--- a/ansible/roles/sortinghat/tasks/main.yml
+++ b/ansible/roles/sortinghat/tasks/main.yml
@@ -14,6 +14,10 @@
       {% endfor %}
       ]
 
+- name: Remove duplicate entries in databases
+  set_fact:
+    databases: "{{ databases | unique }}"
+
 - name: Check databases list
   debug:
     msg: "{{ databases }}"
@@ -42,6 +46,7 @@
     login_password: "{{ mariadb_root_password }}"
   delegate_to: "{{ groups['mariadb'][0] }}"
   loop: "{{ databases }}"
+  when: sortinghat_multi_tenant is defined and sortinghat_multi_tenant == "true"
 
 - name: Create MariaDB service account for SortingHat
   mysql_user:


### PR DESCRIPTION
This commit fixes the `Create databases` job when the SortingHat multi-tenant is disabled. This is only required when multi-tenant is enabled.