### PR TITLE
[sortinghat] Add dedicated workers/queues

### DIFF
--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -9,21 +9,27 @@ nginx_workdir: "/docker/nginx"
 nginx_virtualhosts_workdir: "{{ nginx_workdir }}/conf"
 nginx_log_dir: "{{ nginx_workdir }}/log"
 
-# Create your Nginx virtual host configurations
+# Create your instances configurations
 ## instances:
 ## - project: example
 ##   tenant: example
 ##   public: false
+##   sortinghat:
+##     tenant: example
+##     dedicated_queue: true
+##     openinfra_client_id: ""
+##     openinfra_client_secret: ""
 ##   nginx:
-##   - fqdn: example.com
-##     sortinghat_tenant: example
+##     fqdn: example.com
 ##     http_rest_api: true
 ## - project: example-public
 ##   tenant: example-public
 ##   public: true
+##   sortinghat:
+##     tenant: example-public
+##     dedicated_queue: false
 ##   nginx:
-##   - fqdn: example-public.com
-##     sortinghat_tenant: example-public
+##     fqdn: example-public.com
 ##     http_rest_api: false
 
 # Service hosts

--- a/ansible/roles/nginx/templates/vhost.j2
+++ b/ansible/roles/nginx/templates/vhost.j2
@@ -67,11 +67,7 @@ server {
         uwsgi_param X-Real-IP $remote_addr;
         uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
         uwsgi_param X-Forwarded-Proto $http_x_forwarded_proto;
-{% if instance.nginx.sortinghat_tenant is defined and instance.nginx.sortinghat_tenant != "" %}
-        uwsgi_param HTTP_sortinghat-tenant {{ instance.nginx.sortinghat_tenant | replace('-','_') }};
-{% else %}
-        uwsgi_param HTTP_sortinghat-tenant {{ instance.tenant | replace('-','_') }};
-{% endif %}
+        uwsgi_param HTTP_sortinghat-tenant {{ instance.sortinghat.tenant | replace('-','_') }};
     }
 
     location ~ ^/identities/favicon-grimoirelab.ico {
@@ -84,4 +80,3 @@ server {
       root /opt/gcs/;
     }
 }
-

--- a/ansible/roles/sortinghat/defaults/main.yml
+++ b/ansible/roles/sortinghat/defaults/main.yml
@@ -20,21 +20,27 @@ network:
   bind_host: 0.0.0.0
   publish_host: "{{ ansible_default_ipv4.address }}"
 
-# Instances
+# Create your instances configurations
 ## instances:
 ## - project: example
 ##   tenant: example
 ##   public: false
+##   sortinghat:
+##     tenant: example
+##     dedicated_queue: true
+##     openinfra_client_id: ""
+##     openinfra_client_secret: ""
 ##   nginx:
-##   - fqdn: example.com
-##     sortinghat_tenant: example
+##     fqdn: example.com
 ##     http_rest_api: true
 ## - project: example-public
 ##   tenant: example-public
 ##   public: true
+##   sortinghat:
+##     tenant: example-public
+##     dedicated_queue: false
 ##   nginx:
-##   - fqdn: example-public.com
-##     sortinghat_tenant: example-public
+##     fqdn: example-public.com
 ##     http_rest_api: false
 
 # Multi tenant

--- a/ansible/roles/sortinghat/tasks/main.yml
+++ b/ansible/roles/sortinghat/tasks/main.yml
@@ -6,11 +6,7 @@
       [
       {% for item in instances %}
         {{ "" if loop.first else "," }}
-        {% if item.nginx.sortinghat_tenant is defined and item.nginx.sortinghat_tenant != "" %}
-          "{{ item.nginx.sortinghat_tenant | replace('-','_') }}"
-        {% else %}
-          "{{ item.tenant | replace('-','_') }}"
-        {% endif %}
+        "{{ item.sortinghat.tenant | replace('-','_') }}"
       {% endfor %}
       ]
 
@@ -22,9 +18,9 @@
   debug:
     msg: "{{ databases }}"
 
-- name: Create a list of priviledges
+- name: Create a list of privileges
   set_fact:
-    priviledges: |-
+    privileges: |-
       {
       {% for item in databases %}
         "{{ item }}.*":"ALL,GRANT",
@@ -32,9 +28,9 @@
         "{{ sortinghat_database | replace('-','_') }}.*":"ALL,GRANT"
       }
 
-- name: Check priviledges list
+- name: Check privileges list
   debug:
-    msg: "{{ priviledges }}"
+    msg: "{{ privileges }}"
 
 - name: Create databases
   mysql_db:
@@ -53,7 +49,7 @@
     name: "{{ mariadb_service_account }}"
     host: "{{ ansible_default_ipv4.address }}"
     password: "{{ mariadb_service_account_password }}"
-    priv: "{{ priviledges }}"
+    priv: "{{ privileges }}"
     login_user: root
     login_password: "{{ mariadb_root_password }}"
     login_host: "{{ item }}"
@@ -81,12 +77,16 @@
 - name: "Create SortingHat multi tenant file"
   copy:
     dest: "{{ sortinghat_multi_tenant_list_path }}"
+    mode: 0644
     content: |-
       {
         "tenants": [
-          {% for item in databases %}
+          {% for item in instances %}
             {{ "" if loop.first else "," }}
-            "{{ item }}"
+            {
+               "name": "{{ item.sortinghat.tenant }}",
+               "dedicated_queue": {{ item.sortinghat.dedicated_queue | default(false) }}
+            }
           {% endfor %}
         ]
       }

--- a/ansible/roles/sortinghat_worker/defaults/main.yml
+++ b/ansible/roles/sortinghat_worker/defaults/main.yml
@@ -20,25 +20,27 @@ mariadb_hosts: "{{ groups['mariadb'] | first }}"
 redis_database: "0"
 redis_hosts: "{{ groups['redis'] | first }}"
 
-# OpenInfra
-sortinghat_openinfra_client_id: ""
-sortinghat_openinfra_client_secret: ""
-
-# Instances
+# Create your instances configurations
 ## instances:
 ## - project: example
 ##   tenant: example
 ##   public: false
+##   sortinghat:
+##     tenant: example
+##     dedicated_queue: true
+##     openinfra_client_id: ""
+##     openinfra_client_secret: ""
 ##   nginx:
-##   - fqdn: example.com
-##     sortinghat_tenant: example
+##     fqdn: example.com
 ##     http_rest_api: true
 ## - project: example-public
 ##   tenant: example-public
 ##   public: true
+##   sortinghat:
+##     tenant: example-public
+##     dedicated_queue: false
 ##   nginx:
-##   - fqdn: example-public.com
-##     sortinghat_tenant: example-public
+##     fqdn: example-public.com
 ##     http_rest_api: false
 
 # Multi tenant

--- a/ansible/roles/sortinghat_worker/tasks/main.yml
+++ b/ansible/roles/sortinghat_worker/tasks/main.yml
@@ -6,11 +6,7 @@
       [
       {% for item in instances %}
         {{ "" if loop.first else "," }}
-        {% if item.nginx.sortinghat_tenant is defined and item.nginx.sortinghat_tenant != "" %}
-          "{{ item.nginx.sortinghat_tenant | replace('-','_') }}"
-        {% else %}
-          "{{ item.tenant | replace('-','_') }}"
-        {% endif %}
+        "{{ item.sortinghat.tenant | replace('-','_') }}"
       {% endfor %}
       ]
 
@@ -18,9 +14,9 @@
   debug:
     msg: "{{ databases }}"
 
-- name: Create a list of priviledges
+- name: Create a list of privileges
   set_fact:
-    priviledges: |-
+    privileges: |-
       {
       {% for item in databases %}
         "{{ item }}.*":"ALL,GRANT",
@@ -28,16 +24,16 @@
         "{{ sortinghat_database | replace('-','_') }}.*":"ALL,GRANT"
       }
 
-- name: Check priviledges list
+- name: Check privileges list
   debug:
-    msg: "{{ priviledges }}"
+    msg: "{{ privileges }}"
 
 - name: Create MariaDB service account for SortingHat worker
   mysql_user:
     name: "{{ mariadb_service_account }}"
     host: "{{ ansible_default_ipv4.address }}"
     password: "{{ mariadb_service_account_password }}"
-    priv: "{{ priviledges }}"
+    priv: "{{ privileges }}"
     login_user: root
     login_password: "{{ mariadb_root_password }}"
     login_host: "{{ item }}"
@@ -59,12 +55,16 @@
 - name: "Create SortingHat multi tenant file"
   copy:
     dest: "{{ sortinghat_multi_tenant_list_path }}"
+    mode: 0644
     content: |-
       {
         "tenants": [
-          {% for item in databases %}
+          {% for item in instances %}
             {{ "" if loop.first else "," }}
-            "{{ item }}"
+            {
+               "name": "{{ item.sortinghat.tenant }}",
+               "dedicated_queue": {{ item.sortinghat.dedicated_queue | default(false) }}
+            }
           {% endfor %}
         ]
       }
@@ -90,10 +90,48 @@
       SORTINGHAT_REDIS_HOST: "{{ redis_hosts }}"
       SORTINGHAT_REDIS_PASSWORD: "{{ redis_password }}"
       SORTINGHAT_REDIS_DB: "{{ redis_database }}"
-      SORTINGHAT_OPENINFRA_CLIENT_ID: "{{ sortinghat_openinfra_client_id }}"
-      SORTINGHAT_OPENINFRA_CLIENT_SECRET: "{{ sortinghat_openinfra_client_secret }}"
       SORTINGHAT_MULTI_TENANT: "{{ sortinghat_multi_tenant }}"
       SORTINGHAT_MULTI_TENANT_LIST_PATH: "{{ sortinghat_multi_tenant_list_path }}"
     volumes:
       - "{{ sortinghat_multi_tenant_list_path }}:{{ sortinghat_multi_tenant_list_path }}"
   with_sequence: start=1 end="{{ sortinghat_workers }}"
+
+- name: "Remove old SortingHat dedicated workers {{ item.sortinghat.tenant }}"
+  docker_container:
+    name: "{{ sortinghat_worker_docker_container }}-{{ item.sortinghat.tenant }}"
+    state: absent
+  loop: "{{ instances }}"
+  when:
+    - sortinghat_multi_tenant is defined
+    - sortinghat_multi_tenant == "true"
+    - item.sortinghat.dedicated_queue is defined
+    - item.sortinghat.dedicated_queue == true
+
+- name: "Start SortingHat dedicated worker {{ item.sortinghat.tenant }}"
+  docker_container:
+    name: "{{ sortinghat_worker_docker_container }}-{{ item.sortinghat.tenant }}"
+    image: "{{ sortinghat_worker_docker_image }}:{{ sortinghat_worker_version }}"
+    pull: yes
+    command: "{{ item.sortinghat.tenant }}"
+    env:
+      SORTINGHAT_CONFIG: sortinghat.config.settings
+      SORTINGHAT_SECRET_KEY: "{{ sortinghat_secret_key }}"
+      SORTINGHAT_DB_HOST: "{{ mariadb_hosts }}"
+      SORTINGHAT_DB_USER: "{{ mariadb_service_account }}"
+      SORTINGHAT_DB_PASSWORD: "{{ mariadb_service_account_password }}"
+      SORTINGHAT_DB_DATABASE: "{{ sortinghat_database | replace('-','_') }}"
+      SORTINGHAT_REDIS_HOST: "{{ redis_hosts }}"
+      SORTINGHAT_REDIS_PASSWORD: "{{ redis_password }}"
+      SORTINGHAT_REDIS_DB: "{{ redis_database }}"
+      SORTINGHAT_OPENINFRA_CLIENT_ID: "{{ item.sortinghat.openinfra_client_id | default('') }}"
+      SORTINGHAT_OPENINFRA_CLIENT_SECRET: "{{ item.sortinghat.openinfra_client_secret | default('') }}"
+      SORTINGHAT_MULTI_TENANT: "{{ sortinghat_multi_tenant }}"
+      SORTINGHAT_MULTI_TENANT_LIST_PATH: "{{ sortinghat_multi_tenant_list_path }}"
+    volumes:
+      - "{{ sortinghat_multi_tenant_list_path }}:{{ sortinghat_multi_tenant_list_path }}"
+  loop: "{{ instances }}"
+  when:
+    - sortinghat_multi_tenant is defined
+    - sortinghat_multi_tenant == "true"
+    - item.sortinghat.dedicated_queue is defined
+    - item.sortinghat.dedicated_queue == true

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -140,10 +140,6 @@ all:
     sortinghat_uwsgi_workers: "<sortinghat_uwsgi_workers>"
     sortinghat_uwsgi_threads: "<sortinghat_uwsgi_threads>"
 
-    # Import OpenInfra
-    sortinghat_openinfra_client_id: "<openinfra_client_id>"
-    sortinghat_openinfra_client_secret: "<openinfra_client_secret>"
-
     # Mordred Settings
     mordred_setups_repo_url: <repo_mordred_config.git>
 
@@ -157,6 +153,11 @@ all:
         overwrite_roles: <overwrite_roles>
         sources_repository: "<repo_teneant_a_projects.git>"
         host: <mordred_host_a>
+      sortinghat:
+        tenant: <tenant_name_a>
+        dedicated_queue: true
+        openinfra_client_id: "<openinfra_client_id>"
+        openinfra_client_secret: "<openinfra_client_secret>"
       nginx:
         fqdn: <fqdn-1>
         http_rest_api: false
@@ -168,9 +169,11 @@ all:
         overwrite_roles: <overwrite_roles>
         sources_repository: "<repo_teneant_b_projects.git>"
         host: <mordred_host_b>
+      sortinghat:
+        tenant: <sortinghat_tenant>
+        dedicated_queue: false
       nginx:
         fqdn: <fqdn-2>
-        sortinghat_tenant: <sortinghat_tenant>
         http_rest_api: true
 ```
 
@@ -227,15 +230,12 @@ Replace the entries in `<>` with your values:
 - `sortinghat_workers`: number of SortingHat Workers (by default is `1`).
 - `sortinghat_uwsgi_workers`: number of SortingHat uWSGI workers (by default is `1`).
 - `sortinghat_uwsgi_threads`: number of SortingHat uWSGI threads (by default is `4`).
-- `sortinghat_openinfra_client_id`: OpenInfraID Oauth2 client ID for private API. When the
-  parameter is not set, it will only obtain members from the public API that doesn't contain
-  email information. (by default is "").
-- `sortinghat_openinfra_client_secret`: OpenInfraID Oauth2 client secret for private API (by default is "").
 
 After configuring these parameters, you need to configure the instances of the
 task scheduler (Mordred) and Nginx virtual host. You need a task scheduler for each project
 you want to analyze. Check the section about configuring Mordred for more information
 about how to setup the task scheduler.
+
 - `mordred_setups_repo_url`: URL of the git repository where the configuration
   for each project/mordred instance are stored.
 - `instances`: Mordred and Nginx virtual host configurations. Create as many entries of
@@ -250,10 +250,17 @@ about how to setup the task scheduler.
 - `instances.mordred.sources_repository`: repository with the list of data
    sources to analyze on this project.
 - `instances.mordred.host`: on which mordred VM host will deploy the container (e.g. `0`).
+- `instances.sortingaht.tenant`: the name used here will be used to store the data from
+- `instances.sortinghat.dedicated_queue` (optional): to run identities jobs on a dedicated queue.
+   This will also create a dedicated worker for these tasks. The possible values are `true`
+   or `false`. By default is set to `false`.
+- `instances.sortinghat.openinfra_client_id` (optional): OpenInfraID Oauth2 client ID for private API. When the
+  parameter is not set, it will only obtain members from the public API that doesn't contain
+  email information. (by default is ""). Only works with dedicated queues.
+- `instances.sortinghat.openinfra_client_secret` (optional): OpenInfraID Oauth2 client secret for private
+   API (by default is ""). Only works with dedicated queues.
 - `instances.nginx.fqdn`: full qualified domain name (e.g. `bap.example.com`)
   where BAP will be available.
-- `instances.nginx.tenant` (optional): the name used here will be used to store the data from
-  this project in a separate tenant from the others. By default it will use `instances.tenant`.
 - `instances.nginx.http_rest_api`: Open OpenSearch HTTP rest API only if the variable is defined
   with the value `true`.
 


### PR DESCRIPTION
For BAP 0.19.0/GrimoireLab 0.22.0, the support for dedicated queues on SortingHat was added. Now on,
tenants can used dedicated queues to improve the
performance and security of identities jobs.

This commit adds that support, allowing the creation of dedicated workers for the tenants that require
this configuration. With this change, there will be two types of workers: normal workers, that will get the jobs from the 'default' queue; dedicated workers, one worker for each tenant that will only get jobs from queue with the same tenant name.

Some changes were also required on the ansible config. There's a new entry names 'sortinghat' under the instances var. This entry will store all the specific configuration related to each SortingHat instance. For example, OpenInfra tokens will be now specific to each instance and not shared across all the other instances.