### PR TITLE
Bump BAP version to 0.19.1 release

### DIFF
--- a/ansible/roles/mordred/defaults/main.yml
+++ b/ansible/roles/mordred/defaults/main.yml
@@ -2,7 +2,7 @@
 
 # Bitergia Analytics image and container
 bap_docker_image: bitergia/bitergia-analytics
-bap_version: 0.19.0
+bap_version: 0.19.1
 
 # GrimoireLab configuration
 mordred_workdir: "/docker/mordred"

--- a/ansible/roles/opensearch/defaults/main.yml
+++ b/ansible/roles/opensearch/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # OpenSearch image and container
 opensearch_docker_image: bitergia/bitergia-analytics-opensearch
-opensearch_version: 0.19.0
+opensearch_version: 0.19.1
 opensearch_docker_container: bap_opensearch
 
 # OpenSearch node configuration

--- a/ansible/roles/opensearch_dashboards/defaults/main.yml
+++ b/ansible/roles/opensearch_dashboards/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # docker
 opensearch_dashboards_docker_image: bitergia/bitergia-analytics-opensearch-dashboards
-opensearch_dashboards_version: 0.19.0
+opensearch_dashboards_version: 0.19.1
 opensearch_dashboards_docker_container: bap_opensearch_dashboard
 
 opensearch_dashboards_workdir: "/docker/opensearch_dashboard"

--- a/ansible/roles/sortinghat/defaults/main.yml
+++ b/ansible/roles/sortinghat/defaults/main.yml
@@ -2,7 +2,7 @@
 
 # SortingHat image and container
 sortinghat_docker_image: bitergia/bitergia-analytics-sortinghat
-sortinghat_version: 0.19.0
+sortinghat_version: 0.19.1
 sortinghat_docker_container: bap_sortinghat
 
 # SortingHat node configuration

--- a/ansible/roles/sortinghat_worker/defaults/main.yml
+++ b/ansible/roles/sortinghat_worker/defaults/main.yml
@@ -5,7 +5,7 @@ sortinghat_worker_workdir: "/docker/sortinghat_worker"
 
 # SortingHat image and container
 sortinghat_worker_docker_image: bitergia/bitergia-analytics-sortinghat-worker
-sortinghat_worker_version: 0.19.0
+sortinghat_worker_version: 0.19.1
 sortinghat_worker_docker_container: bap_sortinghat_worker
 sortinghat_workers: 1
 


### PR DESCRIPTION
Updates the default variables to deploy BAP 0.19.1 docker images.