### PR TITLE
[sortinghat] Add all mordred hosts to sortinghat

### DIFF
--- a/ansible/roles/sortinghat/defaults/main.yml
+++ b/ansible/roles/sortinghat/defaults/main.yml
@@ -58,8 +58,8 @@ redis_hosts: "{{ groups['redis'] | first }}"
 sortinghat_debug: "false"
 
 # CSRF and CORS configuration
-sortinghat_allowed_hosts: "localhost,{{ groups['sortinghat'][0] }},{{ groups['mordred'][0] }}"
-sortinghat_cors_allowed_origins: "https://localhost,https://{{ groups['sortinghat'][0] }},https://{{ groups['mordred'][0] }}"
+sortinghat_allowed_hosts: "localhost,{{ groups['sortinghat'][0] }},{{ groups['mordred'] | join(',') }}"
+sortinghat_cors_allowed_origins: "https://localhost,https://{{ groups['sortinghat'][0] }},https://{{ groups['mordred'] | join(',https://') }}"
 
 # NGINX
 


### PR DESCRIPTION
This commit add all mordred hosts to `sortinghat_allowed_hosts` and `sortinghat_cors_allowed_origin` instead of just the first one.