### PR TITLE
[terraform] Add GCP persistent disk

### DIFF
--- a/docs/provision.md
+++ b/docs/provision.md
@@ -134,6 +134,22 @@ the following config parameters. By default, the tunnel won't be created.
 If you have doubts about how to list the users, please check the following
 [link](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iap_tunnel_instance_iam#argument-reference).
 
+By default, all instances will create a boot disk with the same name of the instance.
+To make it persistent, you will have to set `persistent_disks` to true.
+
+- `persistent_disks = true`.
+
+You can also create an extra persistent disk that can be attached to any VMs.
+It will be attached to the same name of VM, by default. When the `<node>_disk_count`
+is not set or the value is `0`, it will use the `<node>_count` value.
+
+- `mariadb_disk_count = 2`
+- `mariadb_disk_attach = "<VM-NAME>"`
+
+You can also create a disk from a snapshot.
+
+- `redis_disk_snapshot = "<SNAPSHOT-DISK-NAME>"`
+
 ```tf
 module "bap_env_gcp" {
   source = "../../modules/bap_env_gcp"
@@ -143,11 +159,16 @@ module "bap_env_gcp" {
 
   custom_tags = ["devel", "research"]
 
+  persistent_disks = true
+
   mariadb_node_count = 1
   mariadb_machine_type = "e2-standard-2"
+  mariadb_disk_count = 2
+  mariadb_disk_attach = "<VM-NAME>"
 
   redis_node_count = 1
   redis_machine_type = "e2-standard-2"
+  redis_disk_snapshot = "<SNAPSHOT-DISK-NAME>
 
   opensearch_node_count = 3
   opensearch_machine_type = "e2-highmem-4"

--- a/terraform/modules/bap_env_gcp/mariadb.tf
+++ b/terraform/modules/bap_env_gcp/mariadb.tf
@@ -12,14 +12,20 @@ module "mariadb" {
 
   machine_type            = var.mariadb_machine_type
   machine_image           = var.mariadb_machine_image
-  disk_size               = var.mariadb_disk_size
-  disk_type               = var.mariadb_disk_type
+  boot_disk_persistent    = var.persistent_disks
+  boot_disk_size          = var.mariadb_boot_disk_size
   zone                    = var.zone
 
   network                 = var.network
   subnetwork              = var.subnetwork
   enable_external_ip      = false
   ansible_use_external_ip = var.mariadb_ansible_use_external_ip
+
+  disk_count              = var.mariadb_disk_count != 0 ? var.mariadb_disk_count : var.mariadb_node_count
+  disk_type               = var.mariadb_disk_type
+  disk_size               = var.mariadb_disk_size
+  disk_snapshot           = var.mariadb_disk_snapshot
+  disk_attach             = var.mariadb_disk_attach
 }
 
 output "mariadb" {

--- a/terraform/modules/bap_env_gcp/mordred.tf
+++ b/terraform/modules/bap_env_gcp/mordred.tf
@@ -12,14 +12,20 @@ module "mordred" {
 
   machine_type            = var.mordred_machine_type
   machine_image           = var.mordred_machine_image
-  disk_size               = var.mordred_disk_size
-  disk_type               = var.mordred_disk_type
+  boot_disk_persistent    = var.persistent_disks
+  boot_disk_size          = var.mordred_boot_disk_size
   zone                    = var.zone
 
   network                 = var.network
   subnetwork              = var.subnetwork
   enable_external_ip      = false
   ansible_use_external_ip = var.mordred_ansible_use_external_ip
+
+  disk_count              = var.mordred_disk_count != 0 ? var.mordred_disk_count : var.mordred_node_count
+  disk_type               = var.mordred_disk_type
+  disk_size               = var.mordred_disk_size
+  disk_snapshot           = var.mordred_disk_snapshot
+  disk_attach             = var.mordred_disk_attach
 }
 
 output "mordred" {

--- a/terraform/modules/bap_env_gcp/nginx.tf
+++ b/terraform/modules/bap_env_gcp/nginx.tf
@@ -12,14 +12,16 @@ module "nginx" {
 
   machine_type            = var.nginx_machine_type
   machine_image           = var.nginx_machine_image
-  disk_size               = var.nginx_disk_size
-  disk_type               = var.nginx_disk_type
+  boot_disk_persistent    = var.persistent_disks
+  boot_disk_size          = var.nginx_boot_disk_size
   zone                    = var.zone
 
   network                 = var.network
   subnetwork              = var.subnetwork
   enable_external_ip      = var.nginx_enable_external_ip
   ansible_use_external_ip = var.nginx_ansible_use_external_ip
+
+  disk_count              = 0
 
   service_account_extra_scopes  = ["storage-ro"]
 }

--- a/terraform/modules/bap_env_gcp/opensearch.tf
+++ b/terraform/modules/bap_env_gcp/opensearch.tf
@@ -12,14 +12,20 @@ module "opensearch" {
 
   machine_type            = var.opensearch_machine_type
   machine_image           = var.opensearch_machine_image
-  disk_size               = var.opensearch_disk_size
-  disk_type               = var.opensearch_disk_type
+  boot_disk_persistent    = var.persistent_disks
+  boot_disk_size          = var.opensearch_boot_disk_size
   zone                    = var.zone
 
   network                 = var.network
   subnetwork              = var.subnetwork
   enable_external_ip      = false
   ansible_use_external_ip = var.opensearch_ansible_use_external_ip
+
+  disk_count              = var.opensearch_disk_count != 0 ? var.opensearch_disk_count : var.opensearch_node_count
+  disk_type               = var.opensearch_disk_type
+  disk_size               = var.opensearch_disk_size
+  disk_snapshot           = var.opensearch_disk_snapshot
+  disk_attach             = var.opensearch_disk_attach
 }
 
 output "opensearch" {

--- a/terraform/modules/bap_env_gcp/opensearch_dashboard.tf
+++ b/terraform/modules/bap_env_gcp/opensearch_dashboard.tf
@@ -12,14 +12,16 @@ module "opensearch_dashboards" {
 
   machine_type            = var.opensearch_dashboards_machine_type
   machine_image           = var.opensearch_dashboards_machine_image
-  disk_size               = var.opensearch_dashboards_disk_size
-  disk_type               = var.opensearch_dashboards_disk_type
+  boot_disk_persistent    = var.persistent_disks
+  boot_disk_size          = var.opensearch_dashboards_boot_disk_size
   zone                    = var.zone
 
   network                 = var.network
   subnetwork              = var.subnetwork
   enable_external_ip      = false
   ansible_use_external_ip = var.opensearch_dashboards_ansible_use_external_ip
+
+  disk_count              = 0
 }
 
 output "opensearch_dashboards" {

--- a/terraform/modules/bap_env_gcp/opensearch_dashboard_anonymous.tf
+++ b/terraform/modules/bap_env_gcp/opensearch_dashboard_anonymous.tf
@@ -12,14 +12,16 @@ module "opensearch_dashboards_anonymous" {
 
   machine_type            = var.opensearch_dashboards_machine_type
   machine_image           = var.opensearch_dashboards_machine_image
-  disk_size               = var.opensearch_dashboards_disk_size
-  disk_type               = var.opensearch_dashboards_disk_type
+  boot_disk_persistent    = var.persistent_disks
+  boot_disk_size          = var.opensearch_dashboards_boot_disk_size
   zone                    = var.zone
 
   network                 = var.network
   subnetwork              = var.subnetwork
   enable_external_ip      = false
   ansible_use_external_ip = var.opensearch_dashboards_ansible_use_external_ip
+
+  disk_count              = 0
 }
 
 output "opensearch_dashboards_anonymous" {

--- a/terraform/modules/bap_env_gcp/redis.tf
+++ b/terraform/modules/bap_env_gcp/redis.tf
@@ -12,14 +12,20 @@ module "redis" {
 
   machine_type            = var.redis_machine_type
   machine_image           = var.redis_machine_image
-  disk_size               = var.redis_disk_size
-  disk_type               = var.redis_disk_type
+  boot_disk_persistent    = var.persistent_disks
+  boot_disk_size          = var.redis_boot_disk_size
   zone                    = var.zone
 
   network                 = var.network
   subnetwork              = var.subnetwork
   enable_external_ip      = false
   ansible_use_external_ip = var.redis_ansible_use_external_ip
+
+  disk_count              = var.redis_disk_count != 0 ? var.redis_disk_count : var.redis_node_count
+  disk_type               = var.redis_disk_type
+  disk_size               = var.redis_disk_size
+  disk_snapshot           = var.redis_disk_snapshot
+  disk_attach             = var.redis_disk_attach
 }
 
 output "redis" {

--- a/terraform/modules/bap_env_gcp/sortinghat.tf
+++ b/terraform/modules/bap_env_gcp/sortinghat.tf
@@ -12,14 +12,16 @@ module "sortinghat" {
 
   machine_type            = var.sortinghat_machine_type
   machine_image           = var.sortinghat_machine_image
-  disk_size               = var.sortinghat_disk_size
-  disk_type               = var.sortinghat_disk_type
+  boot_disk_persistent    = var.persistent_disks
+  boot_disk_size          = var.sortinghat_boot_disk_size
   zone                    = var.zone
 
   network                 = var.network
   subnetwork              = var.subnetwork
   enable_external_ip      = false
   ansible_use_external_ip = var.sortinghat_ansible_use_external_ip
+
+  disk_count              = 0
 }
 
 output "sortinghat" {

--- a/terraform/modules/bap_env_gcp/sortinghat_worker.tf
+++ b/terraform/modules/bap_env_gcp/sortinghat_worker.tf
@@ -12,14 +12,16 @@ module "sortinghat_worker" {
 
   machine_type            = var.sortinghat_worker_machine_type
   machine_image           = var.sortinghat_worker_machine_image
-  disk_size               = var.sortinghat_worker_disk_size
-  disk_type               = var.sortinghat_worker_disk_type
+  boot_disk_persistent    = var.persistent_disks
+  boot_disk_size          = var.sortinghat_worker_boot_disk_size
   zone                    = var.zone
 
   network                 = var.network
   subnetwork              = var.subnetwork
   enable_external_ip      = false
   ansible_use_external_ip = var.sortinghat_worker_ansible_use_external_ip
+
+  disk_count              = 0
 }
 
 output "sortinghat_worker" {

--- a/terraform/modules/bap_env_gcp/variables.tf
+++ b/terraform/modules/bap_env_gcp/variables.tf
@@ -32,6 +32,16 @@ variable "custom_tags" {
   default     = []
 }
 
+variable "machine_image" {
+  type    = string
+  default = "debian-cloud/debian-11"
+}
+
+variable "persistent_disks" {
+  type        = bool
+  description = "Whether the disks will be auto-deleted when the instance is deleted"
+  default     = false
+}
 # MariaDB
 
 variable "mariadb_node_count" {
@@ -49,6 +59,16 @@ variable "mariadb_machine_image" {
   default = "debian-cloud/debian-11"
 }
 
+variable "mariadb_boot_disk_size" {
+  type    = number
+  default = 10
+}
+
+variable "mariadb_disk_count" {
+  type    = number
+  default = 0
+}
+
 variable "mariadb_disk_size" {
   type    = number
   default = 50
@@ -57,6 +77,18 @@ variable "mariadb_disk_size" {
 variable "mariadb_disk_type" {
   type    = string
   default = "pd-standard"
+}
+
+variable "mariadb_disk_attach" {
+  type        = string
+  description = "Instance ID to attach MariaDB disk"
+  default     = ""
+}
+
+variable "mariadb_disk_snapshot" {
+  type = string
+  description = "The source snapshot used to create this disk"
+  default = null
 }
 
 variable "mariadb_ansible_use_external_ip" {
@@ -81,6 +113,16 @@ variable "redis_machine_image" {
   default = "debian-cloud/debian-11"
 }
 
+variable "redis_boot_disk_size" {
+  type    = number
+  default = 10
+}
+
+variable "redis_disk_count" {
+  type    = number
+  default = 0
+}
+
 variable "redis_disk_size" {
   type    = number
   default = 50
@@ -89,6 +131,18 @@ variable "redis_disk_size" {
 variable "redis_disk_type" {
   type    = string
   default = "pd-standard"
+}
+
+variable "redis_disk_attach" {
+  type        = string
+  description = "Instance ID to attach Redis disk"
+  default     = ""
+}
+
+variable "redis_disk_snapshot" {
+  type = string
+  description = "The source snapshot used to create this disk"
+  default = null
 }
 
 variable "redis_ansible_use_external_ip" {
@@ -113,6 +167,16 @@ variable "opensearch_machine_image" {
   default = "debian-cloud/debian-11"
 }
 
+variable "opensearch_boot_disk_size" {
+  type    = number
+  default = 10
+}
+
+variable "opensearch_disk_count" {
+  type    = number
+  default = 0
+}
+
 variable "opensearch_disk_size" {
   type    = number
   default = 200
@@ -122,6 +186,19 @@ variable "opensearch_disk_type" {
   type    = string
   default = "pd-standard"
 }
+
+variable "opensearch_disk_attach" {
+  type        = string
+  description = "Instance ID to attach OpenSearch disk"
+  default     = ""
+}
+
+variable "opensearch_disk_snapshot" {
+  type = string
+  description = "The source snapshot used to create this disk"
+  default = null
+}
+
 
 variable "opensearch_ansible_use_external_ip" {
   type    = bool
@@ -151,9 +228,8 @@ variable "opensearch_dashboards_machine_image" {
   default = "debian-cloud/debian-11"
 }
 
-variable "opensearch_dashboards_disk_size" {
+variable "opensearch_dashboards_boot_disk_size" {
   type    = number
-  # default = 200
   default = 50
 }
 
@@ -184,7 +260,7 @@ variable "nginx_machine_image" {
   default = "debian-cloud/debian-11"
 }
 
-variable "nginx_disk_size" {
+variable "nginx_boot_disk_size" {
   type    = number
   default = 50
 }
@@ -221,6 +297,16 @@ variable "mordred_machine_image" {
   default = "debian-cloud/debian-11"
 }
 
+variable "mordred_boot_disk_size" {
+  type    = number
+  default = 10
+}
+
+variable "mordred_disk_count" {
+  type    = number
+  default = 0
+}
+
 variable "mordred_disk_size" {
   type    = number
   default = 50
@@ -229,6 +315,18 @@ variable "mordred_disk_size" {
 variable "mordred_disk_type" {
   type    = string
   default = "pd-standard"
+}
+
+variable "mordred_disk_attach" {
+  type        = string
+  description = "Instance ID to attach MariaDB disk"
+  default     = ""
+}
+
+variable "mordred_disk_snapshot" {
+  type = string
+  description = "The source snapshot used to create this disk"
+  default = null
 }
 
 variable "mordred_ansible_use_external_ip" {
@@ -253,7 +351,7 @@ variable "sortinghat_machine_image" {
   default = "debian-cloud/debian-11"
 }
 
-variable "sortinghat_disk_size" {
+variable "sortinghat_boot_disk_size" {
   type    = number
   default = 50
 }
@@ -285,7 +383,7 @@ variable "sortinghat_worker_machine_image" {
   default = "debian-cloud/debian-11"
 }
 
-variable "sortinghat_worker_disk_size" {
+variable "sortinghat_worker_boot_disk_size" {
   type    = number
   default = 50
 }

--- a/terraform/modules/bap_gcp_instance/outputs.tf
+++ b/terraform/modules/bap_gcp_instance/outputs.tf
@@ -15,3 +15,11 @@ output "external_ip" {
 output "project_id" {
   value = data.google_project.project.project_id
 }
+
+output "persistent_disk" {
+  value = google_compute_disk.bap.*.name
+}
+
+output "persistent_disk_attached" {
+  value = google_compute_attached_disk.bap.*.instance
+}

--- a/terraform/modules/bap_gcp_instance/variables.tf
+++ b/terraform/modules/bap_gcp_instance/variables.tf
@@ -41,14 +41,44 @@ variable "machine_image" {
   default     = "debian-cloud/debian-11"
 }
 
+variable "boot_disk_persistent" {
+  type        = bool
+  description = "Whether the disk will be keep when the instance is deleted"
+  default     = false
+}
+
+variable "boot_disk_size" {
+  type        = number
+  description = "Boot disk size for each node"
+}
+
+variable "disk_count" {
+  type    = number
+  default = 0
+}
+
 variable "disk_size" {
   type        = number
   description = "Disk size for each node"
+  default     = 10
 }
 
 variable "disk_type" {
   type        = string
   description = "Disk type for each node"
+  default     = "pd-standard"
+}
+
+variable "disk_snapshot" {
+  type = string
+  description = "The source snapshot used to create this disk"
+  default = null
+}
+
+variable "disk_attach" {
+  type        = string
+  description = "Instance ID to attach MariaDB disk"
+  default     = ""
 }
 
 variable "network" {


### PR DESCRIPTION
This commit adds an option to create persistent disks and attach them to instances (VM).

All default boot disk size values are changed to 10 (minimum).

If the disk count is 0 or not set it will use the node count. which means the number of the
disks are the same as the number of node counts for that type of VM and it will attach to
those VMs.

Add these configurations on the `environments.tf` file
```
  mariadb_disk_count = 1
  mariadb_disk_attach = "<YOUR-MARIADB-INSTANCE-NAME>"

  # Create a disk from a snapshot
  disk_redis_snapshot = "<SNAPSHOT-DISK-NAME>"
```