### PR TITLE
[sortinghat] Add "max_conns" parameter at Nginx

### DIFF
--- a/ansible/roles/sortinghat/defaults/main.yml
+++ b/ansible/roles/sortinghat/defaults/main.yml
@@ -64,6 +64,7 @@ sortinghat_cors_allowed_origins: "https://localhost,https://{{ groups['sortingha
 # NGINX
 
 sortinghat_host: "{{ inventory_hostname }}:9314"
+sortinghat_max_conns: 75
 
 ## Image and container
 nginx_docker_image: nginx

--- a/ansible/roles/sortinghat/templates/vhost.j2
+++ b/ansible/roles/sortinghat/templates/vhost.j2
@@ -7,6 +7,10 @@ server {
 }
 {% endif %}
 
+upstream sortinghat {
+    server {{ sortinghat_host }} max_conns={{ sortinghat_max_conns }};
+}
+
 server {
     server_name {{ ansible_hostname }};
 
@@ -39,7 +43,7 @@ server {
 
         include /etc/nginx/conf.d/uwsgi_params;
 
-        uwsgi_pass {{ sortinghat_host }};
+        uwsgi_pass sortinghat;
         uwsgi_param Host $host;
         uwsgi_param X-Real-IP $remote_addr;
         uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -140,6 +140,9 @@ all:
     sortinghat_uwsgi_workers: "<sortinghat_uwsgi_workers>"
     sortinghat_uwsgi_threads: "<sortinghat_uwsgi_threads>"
 
+    # SortingHat Nginx max_conns
+    sortinghat_max_conns: "<sortinghat_max_conns>"
+
     # Mordred Settings
     mordred_setups_repo_url: <repo_mordred_config.git>
 
@@ -230,6 +233,8 @@ Replace the entries in `<>` with your values:
 - `sortinghat_workers`: number of SortingHat Workers (by default is `1`).
 - `sortinghat_uwsgi_workers`: number of SortingHat uWSGI workers (by default is `1`).
 - `sortinghat_uwsgi_threads`: number of SortingHat uWSGI threads (by default is `4`).
+- `sortinghat_max_conns`: limits the maximum number of simultaneous active connections
+  to the proxied server (by default is `75`).
 
 After configuring these parameters, you need to configure the instances of the
 task scheduler (Mordred) and Nginx virtual host. You need a task scheduler for each project


### PR DESCRIPTION
The `max_conns` limits the maximum number of simultaneous active connections to the proxied server to avoid the `upstream timed out` error (uWSGI is limited to 100 simultaneous connections).