### PR TITLE
Update the SortingHat configuration to use BAP settings

### DIFF
--- a/ansible/roles/sortinghat/tasks/main.yml
+++ b/ansible/roles/sortinghat/tasks/main.yml
@@ -159,7 +159,7 @@
     command: --upgrade
     env:
       SORTINGHAT_DEBUG: "{{ sortinghat_debug }}"
-      SORTINGHAT_CONFIG: sortinghat.config.settings
+      SORTINGHAT_CONFIG: sortinghat.config.settings_bap
       SORTINGHAT_SECRET_KEY: "{{ sortinghat_secret_key }}"
       SORTINGHAT_DB_HOST: "{{ mariadb_hosts }}"
       SORTINGHAT_DB_USER: "{{ mariadb_service_account }}"

--- a/ansible/roles/sortinghat_worker/tasks/main.yml
+++ b/ansible/roles/sortinghat_worker/tasks/main.yml
@@ -118,7 +118,7 @@
     image: "{{ sortinghat_worker_docker_image }}:{{ sortinghat_worker_version }}"
     pull: yes
     env:
-      SORTINGHAT_CONFIG: sortinghat.config.settings
+      SORTINGHAT_CONFIG: sortinghat.config.settings_bap
       SORTINGHAT_SECRET_KEY: "{{ sortinghat_secret_key }}"
       SORTINGHAT_DB_HOST: "{{ mariadb_hosts }}"
       SORTINGHAT_DB_USER: "{{ mariadb_service_account }}"
@@ -151,7 +151,7 @@
     pull: yes
     command: "{{ item.tenant }}"
     env:
-      SORTINGHAT_CONFIG: sortinghat.config.settings
+      SORTINGHAT_CONFIG: sortinghat.config.settings_bap
       SORTINGHAT_SECRET_KEY: "{{ sortinghat_secret_key }}"
       SORTINGHAT_DB_HOST: "{{ mariadb_hosts }}"
       SORTINGHAT_DB_USER: "{{ mariadb_service_account }}"


### PR DESCRIPTION
This commit updates the SORTINGHAT_CONFIG env variable to use the new settings (`sortinghat.config.settings_bap`) available in the SortingHat images for BAP.