### PR TITLE
[terraform] Improve alerts

### DIFF
--- a/terraform/modules/bap_alerting_gcp/variables.tf
+++ b/terraform/modules/bap_alerting_gcp/variables.tf
@@ -31,7 +31,7 @@ variable "vm_instance_high_cpu_threshold" {
 variable "vm_instance_high_disk_threshold" {
   type        = string
   description = "Percent usage of disk to fire the alert"
-  default     = "95"
+  default     = "80"
 }
 
 variable "vm_instance_high_memory_threshold" {


### PR DESCRIPTION
This change improves alerts to be more useful:

New alert:
- `VM Instance - High CPU Utilization (1h)`
  - threshold: 75.0%
  - rolling window: 1h

Changes:
- `VM Instance - High CPU Utilization (10min)`
  - from: 5min rolling window
  - to: 10min rolling window
- `VM Instance - High Disk Utilization`
  - from: 95% threshold
  - to: 80% threshold