### PR TITLE
[terraform] Fix High CPU (10min) documentation

### DIFF
--- a/terraform/modules/bap_alerting_gcp/virtual_machine.tf
+++ b/terraform/modules/bap_alerting_gcp/virtual_machine.tf
@@ -7,7 +7,7 @@ resource "google_monitoring_alert_policy" "vm_instance_high_cpu" {
   count         = var.alerts ? 1 : 0
 
   documentation {
-    content   = "CPU utilization on any VM instance is above 80.0% for the last 5m."
+    content   = "CPU utilization on any VM instance is above 80.0% for the last 10m."
     mime_type = "text/markdown"
   }
 


### PR DESCRIPTION
The documentation of `VM Instance - High CPU Utilization (10min)` alert is now updated accordingly to the configuration (rolling window 10min).