### PR TITLE
[OpenID] Fix template and support multiple authorization

### DIFF
--- a/ansible/roles/opensearch_dashboards/defaults/main.yml
+++ b/ansible/roles/opensearch_dashboards/defaults/main.yml
@@ -63,5 +63,7 @@ opensearch_dashboards_cert_fqdn: opensearch.example.org
 #   base_redirect_url: {{ openid_redirect_url }}
 #   logout_url: "{{ openid_logout_url }}"
 #
+## Activate multiple authorization method
+# opensearch_dashboards_multiple_auth: true
 
 docker_network_name: bap_network

--- a/ansible/roles/opensearch_dashboards/templates/opensearch_dashboards.yml.j2
+++ b/ansible/roles/opensearch_dashboards/templates/opensearch_dashboards.yml.j2
@@ -49,9 +49,14 @@ opensearch_security.cookie.secure: true
 opensearch_security.cookie.secure: false
 {% endif %}
 
-{% if openid_dashboards is defined %}
+{% if openid is defined %}
 ### OpenID configuration
+{% if opensearch_dashboards_multiple_auth is defined and opensearch_dashboards_multiple_auth | bool %}
+opensearch_security.auth.type: ["basicauth","openid"]
+opensearch_security.auth.multiple_auth_enabled: true
+{% else  %}
 opensearch_security.auth.type: "openid"
+{% endif %}
 opensearch_security.openid.connect_url: "{{ openid.connect_url }}"
 opensearch_security.openid.client_id: "{{ openid.client_id }}"
 opensearch_security.openid.client_secret: "{{ openid.client_secret }}"

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -304,6 +304,8 @@ the `all.vars` section.
       client_secret: "<client_secret>"
       base_redirect_url: "https://<fnqd>"
       logout_url: "https://<fnqd>/auth/openid/login"
+
+    opensearch_dashboards_multiple_auth: <true|false>
 ```
 
 Replace the entries in `<>` with your values:
@@ -319,6 +321,8 @@ Replace the entries in `<>` with your values:
   platform will be served.
 - `openid.logout_url`: Replace `fnqd` by the full domain where the platform
   will be served.
+- `opensearch_dashboards_multiple_auth`: Enable multiple authorization to use
+  Basic authorization and OpenID. If the value is `false` only OpenID is activated.
 
 #### Custom SSL Certificates (Optional)
 


### PR DESCRIPTION
This commit fixes OpenID configuration int the OpenSearch Dashboards template and supports multiple authorization (Basic authorization and OpenID).

docs/deployment_and_config.md updated accordingly.

Fixes #93 