### PR TITLE
 Allow deployment of all BAP services in a single VM

### DIFF
--- a/ansible/playbooks/all_in_one.yml
+++ b/ansible/playbooks/all_in_one.yml
@@ -1,0 +1,13 @@
+---
+- hosts: all_in_one
+  roles:
+    - mariadb
+    - redis
+    - opensearch
+    - opensearch_dashboards
+    - sortinghat
+    - sortinghat_worker
+    - nginx
+    - mordred
+    - monitoring
+  become: true

--- a/ansible/roles/mariadb/defaults/main.yml
+++ b/ansible/roles/mariadb/defaults/main.yml
@@ -46,3 +46,5 @@ mariadb_backup_script: /usr/local/bin/mariadb_backup.sh
 # Improve MariaDB performance. A good value is 70%-80% of available memory.
 # By default it use e2-standard-2 8G of memory. 6.4G is the 80% of 8G -> 6871947673
 mariadb_innodb_buffer_pool_size: 6871947673
+
+docker_network_name: bap_network

--- a/ansible/roles/mariadb/tasks/main.yml
+++ b/ansible/roles/mariadb/tasks/main.yml
@@ -17,6 +17,10 @@
     mode: 0777
     recurse: true
 
+- name: "Create a docker network: {{ docker_network_name }}"
+  docker_network:
+    name: "{{ docker_network_name }}"
+
 - name: Remove old MariaDB container
   docker_container:
     name: mariadb
@@ -29,6 +33,10 @@
   docker_container:
     name: mariadb
     image: "{{ mariadb_docker_image }}:{{ mariadb_version }}"
+    networks:
+      - name: "{{ docker_network_name }}"
+        aliases:
+          - mariadb
     command: "--wait_timeout={{ mariadb_wait_timeout }} --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --innodb_buffer_pool_size={{ mariadb_innodb_buffer_pool_size }} --long_query_time={{ mariadb_long_query_time }} --log-error=/var/log/mysql/error.log --slow-query-log=1 --slow-query-log-file=/var/log/mysql/slow.log"
     pull: true
     restart_policy: always

--- a/ansible/roles/mariadb/tasks/test.yml
+++ b/ansible/roles/mariadb/tasks/test.yml
@@ -2,7 +2,7 @@
 - name: Create a test service account
   mysql_user:
     name: "test_user"
-    host: localhost
+    host: "{{ ansible_default_ipv4.address }}"
     password: "test_password"
     priv: '*.*:ALL,GRANT'
     login_user: root
@@ -16,7 +16,7 @@
 - name: Drop a test service account
   mysql_user:
     name: "test_user"
-    host: localhost
+    host: "{{ ansible_default_ipv4.address }}"
     password: "test_password"
     priv: '*.*:ALL,GRANT'
     login_user: root

--- a/ansible/roles/mariadb/templates/mariadb_backup.sh.j2
+++ b/ansible/roles/mariadb/templates/mariadb_backup.sh.j2
@@ -2,7 +2,7 @@
 
 USER={{ mariadb_backup_service_account }}
 PASSWORD="{{ mariadb_backup_service_account_password }}"
-HOST={{ groups['mariadb'][0] }}
+HOST={{ groups['all_in_one'][0] | default(groups['mariadb'][0]) }}
 
 DUMP_FOLDER="/tmp"
 DATE=$(date "+%Y%m%d")

--- a/ansible/roles/mordred/defaults/main.yml
+++ b/ansible/roles/mordred/defaults/main.yml
@@ -34,5 +34,7 @@ mordred_aliases_url: https://raw.githubusercontent.com/chaoss/grimoirelab-sirmor
 ##     overwrite_roles: true
 ##     sources_repository: "<PROJECT2_SOURCE_REPO_URL>"
 ##     host: 1
+mariadb_hosts: "{{ groups['all_in_one'][0] | default(groups['mariadb'][0]) }}"
+opensearch_host: "{{ groups['all_in_one'][0] | default(groups['opensearch'][0]) }}"
 
-mariadb_hosts: "{{ groups['mariadb'] }}"
+docker_network_name: bap_network

--- a/ansible/roles/mordred/tasks/configure_instance.yml
+++ b/ansible/roles/mordred/tasks/configure_instance.yml
@@ -3,7 +3,7 @@
 - name: "Set {{ instance.project }} instance variables"
   set_fact:
     instance_dir: "{{ mordred_instances_dir }}/{{ instance.project }}"
-  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  delegate_to: "{{ groups['all_in_one'][0] | default(groups['mordred'][instance.mordred.host]) }}"
   run_once: true
 
 - name: "Ensure {{ instance.project }} instance directories are created"
@@ -18,7 +18,7 @@
     - "{{ instance_dir }}/logs"
     - "{{ instance_dir }}/sources"
     - "{{ instance_dir }}/perceval-cache"
-  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  delegate_to: "{{ groups['all_in_one'][0] | default(groups['mordred'][instance.mordred.host]) }}"
   run_once: true
 
 - name: "Add {{ instance.tenant }} tenant to aliases.json file"
@@ -37,7 +37,7 @@
     owner: grimoire
     group: grimoire
     mode: '0640'
-  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  delegate_to: "{{ groups['all_in_one'][0] | default(groups['mordred'][instance.mordred.host]) }}"
   run_once: true
 
 - name: "Checkout {{ instance.project }} sources repo"
@@ -48,7 +48,7 @@
     dest: "{{ instance_dir }}/sources"
     force: true
   when: instance.mordred.sources_repository is defined
-  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  delegate_to: "{{ groups['all_in_one'][0] | default(groups['mordred'][instance.mordred.host]) }}"
   run_once: true
 
 - name: "Change {{ instance.project }} sources permissions"
@@ -58,7 +58,7 @@
     owner: grimoire
     group: grimoire
     mode: '0774'
-  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  delegate_to: "{{ groups['all_in_one'][0] | default(groups['mordred'][instance.mordred.host]) }}"
   run_once: true
 
 - name: "Create cron job to pull changes from {{ instance.project }} sources repo"
@@ -66,13 +66,13 @@
     name: "Pull {{ instance.project }} sources"
     user: "{{ ansible_user_id }}"
     job: "cd {{ instance_dir }}/sources && git pull"
-  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  delegate_to: "{{ groups['all_in_one'][0] | default(groups['mordred'][instance.mordred.host]) }}"
   run_once: true
 
 - name: "Create MariaDB service account for {{ instance.project }}"
   mysql_user:
     name: "{{ mariadb_service_account }}"
-    host: "{{ ansible_default_ipv4.address }}"
+    host: "{{ '172.%' if 'all_in_one' in groups else ansible_default_ipv4.address }}"
     password: "{{ mariadb_service_account_password }}"
     priv: '*.*:ALL,GRANT'
     login_user: root
@@ -85,33 +85,33 @@
   until: result is success
   with_items:
     - "{{ mariadb_hosts }}"
-  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  delegate_to: "{{ groups['all_in_one'][0] | default(groups['mordred'][instance.mordred.host]) }}"
   run_once: true
 
 - name: Set anonymous role if opensearch_dashboards_anonymous is defined and the instance is public
   set_fact:
     anonymous: "{% if 'opensearch_dashboards_anonymous' in groups and groups['opensearch_dashboards_anonymous'] and instance.public %} -a {% else %} {% endif %}"
-  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  delegate_to: "{{ groups['all_in_one'][0] | default(groups['mordred'][instance.mordred.host]) }}"
   run_once: true
 
 - name: Add --force option (create_roles_tenat.py) if overwrite_roles is defined and the value is true
   set_fact:
     overwrite_roles: "{% if instance.overwrite_roles is defined and instance.overwrite_roles %} --force {% else %} {% endif %}"
-  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  delegate_to: "{{ groups['all_in_one'][0] | default(groups['mordred'][instance.mordred.host]) }}"
   run_once: true
 
 - name: "Create roles and tenant for {{ instance.project }}"
   become: false
   command: >-
     python3 {{ role_path }}/files/create_roles_tenant.py
-    https://{{ opensearch_admin_user }}:{{ opensearch_admin_password }}@{{ groups['opensearch'][0] }}:9200 {{ instance.tenant }} {{ anonymous }}
+    https://{{ opensearch_admin_user }}:{{ opensearch_admin_password }}@{{ opensearch_host }}:9200 {{ instance.tenant }} {{ anonymous }}
     {{ overwrite_roles }}
   delegate_to: localhost
   run_once: true
 
 - name: "Create mordred user for {{ instance.project }}"
   uri:
-    url: "https://{{ groups['opensearch'][0] }}:9200/_plugins/_security/api/internalusers/{{ instance.tenant }}_mordred"
+    url: "https://{{ opensearch_host }}:9200/_plugins/_security/api/internalusers/{{ instance.tenant }}_mordred"
     url_username: "{{ opensearch_admin_user }}"
     url_password: "{{ opensearch_admin_password }}"
     force_basic_auth: yes
@@ -127,5 +127,5 @@
   retries: 10
   delay: 2
   become: false
-  delegate_to: "{{ groups['mordred'][instance.mordred.host] }}"
+  delegate_to: "{{ groups['all_in_one'][0] | default(groups['mordred'][instance.mordred.host]) }}"
   run_once: true

--- a/ansible/roles/mordred/tasks/main.yml
+++ b/ansible/roles/mordred/tasks/main.yml
@@ -16,19 +16,27 @@
 - name: Configure Mordred
   import_tasks: configure.yml
 
+- name: "Create a docker network: {{ docker_network_name }}"
+  docker_network:
+    name: "{{ docker_network_name }}"
+
 - name: Remove old Mordred container(s)
   docker_container:
     name: "mordred_{{ item.project }}"
     state: absent
   with_items:
     - "{{ instances }}"
-  delegate_to: "{{ groups['mordred'][item.mordred.host] }}"
+  delegate_to: "{{ groups['all_in_one'][0] | default(groups['mordred'][item.mordred.host]) }}"
   run_once: true
 
 - name: docker
   docker_container:
     name: "mordred_{{ item.project }}"
     image: "{{ bap_docker_image }}:{{ bap_version }}"
+    networks:
+      - name: "{{ docker_network_name }}"
+        aliases:
+          - "mordred-{{ item.project }}"
     volumes:
     - "{{ mordred_ssh_dir }}:/home/grimoire/.ssh/"
     - "{{ mordred_setups_dir }}/{{ item.project }}/setup.cfg:/home/grimoire/conf/setup.cfg"
@@ -38,5 +46,5 @@
     - "{{ mordred_instances_dir }}/{{ item.project }}/perceval-cache/:/home/grimoire/.perceval/"
   with_items:
     - "{{ instances }}"
-  delegate_to: "{{ groups['mordred'][item.mordred.host] }}"
+  delegate_to: "{{ groups['all_in_one'][0] | default(groups['mordred'][item.mordred.host]) }}"
   run_once: true

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -33,8 +33,8 @@ nginx_log_dir: "{{ nginx_workdir }}/log"
 ##     http_rest_api: false
 
 # Service hosts
-opensearch_endpoint: "https://{{ hostvars[(groups['opensearch'][0])].ansible_default_ipv4.address }}:9200"
-sortinghat_host: "{{ hostvars[(groups['sortinghat'][0])].ansible_default_ipv4.address }}:9314"
+opensearch_endpoint: "https://{{ ansible_default_ipv4.address | list if 'all_in_one' in groups else  hostvars[(groups['opensearch'][0])].ansible_default_ipv4.address }}:9200"
+sortinghat_host: "{{ ansible_default_ipv4.address if 'all_in_one' in groups else  hostvars[(groups['sortinghat'][0])].ansible_default_ipv4.address }}:9314"
 
 # Certificates configuration
 ## Let's Encrypt configuration
@@ -67,3 +67,5 @@ nginx_keys_workdir: /docker/nginx/keys
 gcloud_apt_deb_ubuntu_repository: >-
   deb [signed-by=/usr/share/keyrings/cloud.google.gpg]
   https://packages.cloud.google.com/apt cloud-sdk main
+
+docker_network_name: bap_network

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -65,6 +65,10 @@
     loop_var: instance
   when: custom_cert is undefined
 
+- name: "Create a docker network: {{ docker_network_name }}"
+  docker_network:
+    name: "{{ docker_network_name }}"
+
 # Start Nginx container to allow certbot to create certificates.
 - name: Start NGINX container with acme-challenge to create certificates using certbot
   docker_container:
@@ -91,6 +95,10 @@
     image: "{{ nginx_docker_image }}:{{ nginx_version }}"
     restart: yes
     volumes: "{{ nginx_volumes }}"
+    networks:
+      - name: "{{ docker_network_name }}"
+        aliases:
+          - "{{ nginx_docker_container | replace('_','-') }}"
     ports:
       - "80:80"
       - "443:443"

--- a/ansible/roles/nginx/templates/opensearch_nodes.j2
+++ b/ansible/roles/nginx/templates/opensearch_nodes.j2
@@ -1,5 +1,9 @@
 upstream opensearch_nodes {
+{% if 'all_in_one' in groups and inventory_hostname in groups['all_in_one'] %}
+    server {{ ansible_default_ipv4.address }}:9200;
+{% else %}
 {% for node in groups['opensearch'] %}
     server {{ hostvars[node].ansible_default_ipv4.address }}:9200;
 {% endfor %}
+{% endif %}
 }

--- a/ansible/roles/nginx/templates/status.conf.j2
+++ b/ansible/roles/nginx/templates/status.conf.j2
@@ -1,10 +1,10 @@
 server {
    listen 80;
-   server_name {{ hostvars[groups['nginx'][0]]['ansible_default_ipv4']['address'] }};
+   server_name {{ ansible_default_ipv4.address if 'all_in_one' in groups else  hostvars[groups['nginx'][0]]['ansible_default_ipv4']['address'] }};
    location /nginx_status {
        stub_status on;
        access_log off;
-       allow {{ hostvars[groups['nginx'][0]]['ansible_default_ipv4']['address'] }};
+       allow {{ ansible_default_ipv4.address if 'all_in_one' in groups else hostvars[groups['nginx'][0]]['ansible_default_ipv4']['address'] }};
        deny all;
    }
    location / {

--- a/ansible/roles/nginx/templates/vhost.j2
+++ b/ansible/roles/nginx/templates/vhost.j2
@@ -29,7 +29,10 @@ server {
 
     rewrite ^/$ $scheme://$http_host/app/dashboards#/view/Overview permanent;
     location / {
-{% if instance.public is defined and instance.public == true %}
+{% if 'all_in_one' in groups and inventory_hostname in groups['all_in_one'] %}
+        proxy_pass https://{{ ansible_default_ipv4.address }}:5601/;
+        proxy_redirect https://{{ ansible_default_ipv4.address }}:5601/ /;
+{% elif instance.public is defined and instance.public == true %}
         proxy_pass https://{{ hostvars[(groups['opensearch_dashboards_anonymous'][0])].ansible_default_ipv4.address }}:5601/;
         proxy_redirect https://{{ hostvars[(groups['opensearch_dashboards_anonymous'][0])].ansible_default_ipv4.address }}:5601/ /;
 {% else %}

--- a/ansible/roles/opensearch/defaults/main.yml
+++ b/ansible/roles/opensearch/defaults/main.yml
@@ -86,3 +86,5 @@ opensearch_snapshots_json_file: "{{ opensearch_workdir }}/snapshot.json"
 opensearch_keys_dir:  "{{ opensearch_workdir }}/keys"
 gcp_service_account_file: "{{ opensearch_keys_dir }}/gcs_credentials.json"
 gcs_cred_file_container: "/usr/share/opensearch/config/gcs_credentials.json"
+
+docker_network_name: bap_network

--- a/ansible/roles/opensearch/tasks/main.yml
+++ b/ansible/roles/opensearch/tasks/main.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: All in one host
+  set_fact:
+    discovery_seed_hosts: "{{ ansible_default_ipv4.address }}"
+    cluster_initial_master_nodes: "{{ groups['all_in_one'] }}"
+    number_of_shards: 1
+  when: "'all_in_one' in groups and inventory_hostname in groups['all_in_one']"
+
 - name: Create OpenSearch configuration directory
   file:
     path: "{{ opensearch_workdir }}"
@@ -50,10 +57,18 @@
     name: "{{ opensearch_docker_container }}"
     state: absent
 
+- name: "Create a docker network: {{ docker_network_name }}"
+  docker_network:
+    name: "{{ docker_network_name }}"
+
 - name: Start OpenSearch container
   docker_container:
     name: "{{ opensearch_docker_container }}"
     image: "{{ opensearch_docker_image }}:{{ opensearch_version }}"
+    networks:
+      - name: "{{ docker_network_name }}"
+        aliases:
+          - "{{ opensearch_docker_container | replace('_','-') }}"
     env:
       DISABLE_INSTALL_DEMO_CONFIG=true
       bootstrap.memory_lock=true

--- a/ansible/roles/opensearch_dashboards/defaults/main.yml
+++ b/ansible/roles/opensearch_dashboards/defaults/main.yml
@@ -17,7 +17,7 @@ network:
 
 #
 opensearch_hosts:
-  "{{ groups['opensearch'] | map('extract', hostvars, ['ansible_default_ipv4','address']) | list }}"
+  "{{ ansible_all_ipv4_addresses if 'all_in_one' in groups else groups['opensearch'] | map('extract', hostvars, ['ansible_default_ipv4','address']) | list }}"
 opensearch:
   endpoints: "{{ ['https'] | product(opensearch_hosts) | map('join','://') | list | product(['9200']) | map('join', ':') | list }}"
   username: kibanaserver
@@ -63,3 +63,5 @@ opensearch_dashboards_cert_fqdn: opensearch.example.org
 #   base_redirect_url: {{ openid_redirect_url }}
 #   logout_url: "{{ openid_logout_url }}"
 #
+
+docker_network_name: bap_network

--- a/ansible/roles/opensearch_dashboards/tasks/main.yml
+++ b/ansible/roles/opensearch_dashboards/tasks/main.yml
@@ -15,6 +15,10 @@
     group: '1000'
     mode: 0644
 
+- name: "Create a docker network: {{ docker_network_name }}"
+  docker_network:
+    name: "{{ docker_network_name }}"
+
 - name: Remove old private OpenSearch Dashboards container
   docker_container:
     name: "{{ opensearch_dashboards_docker_container }}"
@@ -29,10 +33,20 @@
   delegate_to: "{{ groups['opensearch_dashboards_anonymous'][0] }}"
   when: "'opensearch_dashboards_anonymous' in groups and inventory_hostname in groups['opensearch_dashboards_anonymous']"
 
+- name: Remove old local OpenSearch Dashboards container
+  docker_container:
+    name: "{{ opensearch_dashboards_docker_container }}"
+    state: absent
+  when: "'all_in_one' in groups and inventory_hostname in groups['all_in_one']"
+
 - name: Start private OpenSearch Dashboards container(s)
   docker_container:
     name: "{{ opensearch_dashboards_docker_container }}"
     image: "{{ opensearch_dashboards_docker_image }}:{{ opensearch_dashboards_version }}"
+    networks:
+      - name: "{{ docker_network_name }}"
+        aliases:
+          - "{{ opensearch_dashboards_docker_container | replace('_','-') }}"
     env:
       NODE_OPTIONS=--max-old-space-size=1000
     volumes:
@@ -46,6 +60,10 @@
   docker_container:
     name: "{{ opensearch_dashboards_docker_container }}_anonymous"
     image: "{{ opensearch_dashboards_docker_image }}:{{ opensearch_dashboards_version }}"
+    networks:
+      - name: "{{ docker_network_name }}"
+        aliases:
+          - "{{ opensearch_dashboards_docker_container | replace('_','-') }}-anonymous"
     env:
       NODE_OPTIONS=--max-old-space-size=1000
     volumes:
@@ -54,3 +72,19 @@
       - "{{ network.bind_host }}:5601:5601"
   delegate_to: "{{ groups['opensearch_dashboards_anonymous'][0] }}"
   when: "'opensearch_dashboards_anonymous' in groups and inventory_hostname in groups['opensearch_dashboards_anonymous']"
+
+- name: Start local OpenSearch Dashboards container(s)
+  docker_container:
+    name: "{{ opensearch_dashboards_docker_container }}"
+    image: "{{ opensearch_dashboards_docker_image }}:{{ opensearch_dashboards_version }}"
+    networks:
+      - name: "{{ docker_network_name }}"
+        aliases:
+          - "{{ opensearch_dashboards_docker_container | replace('_','-') }}"
+    env:
+      NODE_OPTIONS=--max-old-space-size=1000
+    volumes:
+      - "{{ opensearch_dashboards_workdir }}/opensearch_dashboards.yml:/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml"
+    ports:
+      - "{{ network.bind_host }}:5601:5601"
+  when: "'all_in_one' in groups and inventory_hostname in groups['all_in_one']"

--- a/ansible/roles/redis/defaults/main.yml
+++ b/ansible/roles/redis/defaults/main.yml
@@ -11,3 +11,5 @@ redis_log_dir: "{{ redis_workdir }}/log"
 network:
   bind_host: 0.0.0.0
   publish_host: "{{ ansible_default_ipv4.address }}"
+
+docker_network_name: bap_network

--- a/ansible/roles/redis/tasks/main.yml
+++ b/ansible/roles/redis/tasks/main.yml
@@ -19,6 +19,10 @@
     dest: "{{ redis_workdir }}/overrides.conf"
     mode: 0664
 
+- name: "Create a docker network: {{ docker_network_name }}"
+  docker_network:
+    name: "{{ docker_network_name }}"
+
 - name: Remove old redis container
   docker_container:
     name: "{{ redis_docker_container }}"
@@ -28,6 +32,10 @@
   docker_container:
     name: "{{ redis_docker_container }}"
     image: "{{ redis_docker_image }}:{{ redis_version }}"
+    networks:
+      - name: "{{ docker_network_name }}"
+        aliases:
+          - "{{ redis_docker_container | replace('_','-') }}"
     env:
       REDIS_PASSWORD: "{{ redis_password }}"
       REDIS_DISABLE_COMMANDS: FLUSHDB,FLUSHALL,CONFIG

--- a/ansible/roles/sortinghat/defaults/main.yml
+++ b/ansible/roles/sortinghat/defaults/main.yml
@@ -49,9 +49,10 @@ sortinghat_multi_tenant_list_path: "{{ sortinghat_workdir }}/sortinghat_multi_te
 
 # Database
 sortinghat_database: sortinghat_db
-mariadb_hosts: "{{ groups['mariadb'] | first }}"
+
+mariadb_hosts: "{{ groups['all_in_one'][0] | default(groups['mariadb'][0]) }}"
 redis_database: "0"
-redis_hosts: "{{ groups['redis'] | first }}"
+redis_hosts: "{{ groups['all_in_one'][0] | default(groups['redis'][0]) }}"
 
 
 # Debug mode (on: 'true', '1'; off: 'false', '0')
@@ -72,7 +73,7 @@ nginx_version: stable
 nginx_docker_container: nginx
 
 ## Node configuration
-nginx_workdir: "/docker/nginx"
+nginx_workdir: /docker/nginx
 nginx_virtualhosts_workdir: "{{ nginx_workdir }}/conf"
 
 ## Enable SSL
@@ -86,3 +87,5 @@ certs_dir: "{{ nginx_workdir }}/certs"
 # custom_cert:
 #   cert: foo/cert.crt
 #   key: foo/cert.key
+
+docker_network_name: bap_network

--- a/ansible/roles/sortinghat/tasks/main.yml
+++ b/ansible/roles/sortinghat/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: All in one host (sortinghat hosts and origins)
+  set_fact:
+    sortinghat_allowed_hosts: "localhost,nginx,{{ groups['all_in_one'][0] }}"
+    sortinghat_cors_allowed_origins_regexes: "https://localhost,https://nginx,https://{{ groups['all_in_one'][0] }}"
+  when: "'all_in_one' in groups and inventory_hostname in groups['all_in_one']"
+
 - name: "Create SortingHat tenants info"
   set_fact:
     tenants_info: |-
@@ -77,14 +83,14 @@
     state: present
     login_user: root
     login_password: "{{ mariadb_root_password }}"
-  delegate_to: "{{ groups['mariadb'][0] }}"
+  delegate_to: "{{ groups['all_in_one'][0] | default(groups['mariadb'][0]) }}"
   loop: "{{ databases }}"
   when: sortinghat_multi_tenant is defined and sortinghat_multi_tenant == "true"
 
 - name: Create MariaDB service account for SortingHat
   mysql_user:
     name: "{{ mariadb_service_account }}"
-    host: "{{ ansible_default_ipv4.address }}"
+    host: "{{ '172.%' if 'all_in_one' in groups else ansible_default_ipv4.address }}"
     password: "{{ mariadb_service_account_password }}"
     priv: "{{ privileges }}"
     login_user: root
@@ -127,6 +133,10 @@
           {% endfor %}
         ]
       }
+
+- name: "Create a docker network: {{ docker_network_name }}"
+  docker_network:
+    name: "{{ docker_network_name }}"
 
 - name: Remove old SortingHat container
   docker_container:
@@ -179,6 +189,10 @@
   docker_container:
     name: "{{ sortinghat_docker_container }}"
     image: "{{ sortinghat_docker_image }}:{{ sortinghat_version }}"
+    networks:
+      - name: "{{ docker_network_name }}"
+        aliases:
+          - "{{ sortinghat_docker_container | replace('_','-') }}"
     pull: yes
     command: --upgrade
     env:
@@ -212,6 +226,10 @@
 - name: "Add {{ sortinghat_superuser_name }} user to all tenants for {{ ansible_hostname }}"
   command: >
     docker exec {{ sortinghat_docker_container }} /opt/venv/bin/sortinghat-admin set-user-tenant {{ sortinghat_superuser_name }} {{ item }} {{ item }}
+  register: result
+  retries: 10
+  delay: 10
+  until: result is success
   loop: "{{ databases }}"
   when: sortinghat_multi_tenant is defined and sortinghat_multi_tenant == "true"
 
@@ -230,3 +248,4 @@
 
 - name: Configure Nginx
   include_tasks: nginx.yml
+  when: "'all_in_one' not in groups"

--- a/ansible/roles/sortinghat/tasks/nginx.yml
+++ b/ansible/roles/sortinghat/tasks/nginx.yml
@@ -3,6 +3,11 @@
 - name: Configure virtualhost(s)
   include_tasks: virtualhost.yml
 
+- name: Create a network
+  docker_network:
+    name: "{{ docker_network_name }}"
+  when: "'all_in_one' in groups"
+
 - name: Remove old NGINX container
   docker_container:
     name: "{{ nginx_docker_container }}"

--- a/ansible/roles/sortinghat_worker/defaults/main.yml
+++ b/ansible/roles/sortinghat_worker/defaults/main.yml
@@ -46,3 +46,5 @@ redis_hosts: "{{ groups['redis'] | first }}"
 # Multi tenant
 sortinghat_multi_tenant: "true"
 sortinghat_multi_tenant_list_path: "{{ sortinghat_worker_workdir }}/sortinghat_multi_tenant_list_path.json"
+
+docker_network_name: bap_network

--- a/ansible/roles/sortinghat_worker/tasks/main.yml
+++ b/ansible/roles/sortinghat_worker/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: All in one host (MariaDB and Redis hosts)
+  set_fact:
+    mariadb_hosts: "{{ groups['all_in_one'][0] }}"
+    redis_hosts: "{{ groups['all_in_one'][0] }}"
+  when: "'all_in_one' in groups and inventory_hostname in groups['all_in_one']"
+
 - name: "Create SortingHat tenants info"
   set_fact:
     tenants_info: |-
@@ -68,7 +74,7 @@
 - name: Create MariaDB service account for SortingHat worker
   mysql_user:
     name: "{{ mariadb_service_account }}"
-    host: "{{ ansible_default_ipv4.address }}"
+    host: "{{ '172.%' if 'all_in_one' in groups else ansible_all_ipv4_addresses }}"
     password: "{{ mariadb_service_account_password }}"
     priv: "{{ privileges }}"
     login_user: root
@@ -106,6 +112,10 @@
         ]
       }
 
+- name: "Create a docker network: {{ docker_network_name }}"
+  docker_network:
+    name: "{{ docker_network_name }}"
+
 - name: Remove old SortingHat worker container
   docker_container:
     name: "{{ sortinghat_worker_docker_container }}-{{ item }}"
@@ -116,6 +126,10 @@
   docker_container:
     name: "{{ sortinghat_worker_docker_container }}-{{ item }}"
     image: "{{ sortinghat_worker_docker_image }}:{{ sortinghat_worker_version }}"
+    networks:
+      - name: "{{ docker_network_name }}"
+        aliases:
+          - "{{ sortinghat_worker_docker_container | replace('_','-') }}-{{ item }}"
     pull: yes
     env:
       SORTINGHAT_CONFIG: sortinghat.config.settings_bap
@@ -148,6 +162,10 @@
   docker_container:
     name: "{{ sortinghat_worker_docker_container }}-{{ item.tenant }}"
     image: "{{ sortinghat_worker_docker_image }}:{{ sortinghat_worker_version }}"
+    networks:
+      - name: "{{ docker_network_name }}"
+        aliases:
+          - "{{ sortinghat_worker_docker_container | replace('_','-') }}-{{ item.tenant }}"
     pull: yes
     command: "{{ item.tenant }}"
     env:

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -12,7 +12,9 @@ components to fetch and analyze data. Data visualizations and storage are provid
 by [OpenSearch](https://opensearch.org/).
 
 The platform is deployed as a set of components. The diagram below shows how they
-interact with each other. These components are:
+interact with each other. By default, each component is deployed in different VMs
+but there is an option to deploy all components **on a single VM**. See these sections
+of [terraform](/docs/provision.md#deploy-all-bap-services-in-a-single-vm-opcional) and [ansible](/docs/deployment_and_config.md#deploy-all-bap-services-in-a-single-vm-optional). These components are:
 
 * **Control node**: its aim is to create the infrastructure and to provision the
   machines. It creates the other nodes using Google Cloud Platform APIs via

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -3,6 +3,8 @@
 Once the infrastructure has been created, it's time to deploy and configure
 BAP with Ansible. The toolkit provides a set of playbooks and roles that
 will do this job.
+If you want to deploy all BAP services in one VM, in the section **4. Deploy the platform**,
+you will have to run [all_in_one.yml](/docs/deployment_and_config.md#deploy-all-bap-services-in-a-single-vm-optional) playbook.
 
 ## 1. Install Ansible and Dependencies
 
@@ -389,6 +391,14 @@ directory, run the following command to deploy and configure it:
 
 ```terminal
 ansible-playbook -i environments/<environment>/inventory/ playbooks/all.yml
+```
+
+### Deploy all BAP services in a single VM (Optional)
+
+Run `all_in_one.yml` instead of running `all.yml` playbook.
+
+```terminal
+ansible-playbook -i environments/<environment>/inventory/ playbooks/all_in_one.yml
 ```
 
 After some minutes, the platform will be accessible in the domain you configured

--- a/docs/provision.md
+++ b/docs/provision.md
@@ -100,7 +100,12 @@ Replace the entries in `<>` with your values:
    of the bucket defined in the [prerequisites section](./prerequisites.md).
 - `prefix`: name of the folder where the state will be stored.
 
-### GCP Module Settings (`environment.tf`)
+#### GCP Module Settings (`environment.tf`)
+
+To provision all BAP services on a single VM, check [this section](/docs/provision.md#deploy-all-bap-services-in-a-single-vm-opcional).
+
+Take into account that the method to deploy and configure with ansible
+[is also different](/docs/deployment_and_config.md#deploy-all-bap-services-in-a-single-vm-optional).
 
 Below, you can find the different variables you can configure for this module.
 You can set the number of nodes and virtual machine type for each component
@@ -197,6 +202,44 @@ output "bap_env_gcp" {
   value = module.bap_env_gcp
 }
 ```
+
+##### Deploy all BAP services in a single VM (Opcional)
+
+Set `all_in_one_node_count = 1` and set to 0 the rest of `*_node_count = 0`.
+
+```tf
+module "bap_env_gcp" {
+  source = "../../modules/bap_env_gcp"
+
+  prefix = "test"
+  zone = var.zone
+
+  custom_tags = ["devel", "research"]
+
+  persistent_disks = true
+
+  all_in_one_node_count = 1
+  all_in_one_machine_type = "e2-standard-4"
+
+  # Set to 0 the rest of the services
+  mariadb_node_count = 0
+  mariadb_disk_count = 0
+  redis_node_count = 0
+  opensearch_node_count = 0
+  opensearch_dashboards_node_count = 0
+  opensearch_dashboards_anonymous_node_count = 0
+  nginx_node_count = 0
+  mordred_node_count = 0
+  sortinghat_node_count = 0
+  sortinghat_worker_node_count = 0
+}
+
+output "bap_env_gcp" {
+  value = module.bap_env_gcp
+}
+```
+
+##### Alerts
 
 If you want to include the basic alerts this toolkit offers, then, add the
 following code at the end of the `environment.tf` file:

--- a/terraform/modules/bap_env_gcp/all_in_one.tf
+++ b/terraform/modules/bap_env_gcp/all_in_one.tf
@@ -1,0 +1,33 @@
+module "all_in_one" {
+  source = "../bap_gcp_instance"
+
+  prefix                  = var.prefix
+  name                    = "all-in-one"
+  node_count              = var.all_in_one_node_count
+  tags                    = flatten([
+                              "all-in-one",   "http-server", "https-server",
+                              var.custom_tags
+                            ])
+  ansible_groups          = ["all_in_one"]
+
+  machine_type            = var.all_in_one_machine_type
+  machine_image           = var.all_in_one_machine_image
+  boot_disk_persistent    = var.persistent_disks
+  boot_disk_size          = var.all_in_one_boot_disk_size
+  zone                    = var.zone
+
+  network                 = var.network
+  subnetwork              = var.subnetwork
+  enable_external_ip      = true
+  ansible_use_external_ip = var.all_in_one_ansible_use_external_ip
+
+  disk_count              = var.all_in_one_disk_count != 0 ? var.all_in_one_disk_count : var.all_in_one_node_count
+  disk_type               = var.all_in_one_disk_type
+  disk_size               = var.all_in_one_disk_size
+  disk_snapshot           = var.all_in_one_disk_snapshot
+  disk_attach             = var.all_in_one_disk_attach
+}
+
+output "all_in_one" {
+  value = module.all_in_one
+}

--- a/terraform/modules/bap_env_gcp/variables.tf
+++ b/terraform/modules/bap_env_gcp/variables.tf
@@ -434,3 +434,57 @@ variable "network_iap_tunnel" {
   description = "Activate IAP tunnel"
   default     = false
 }
+
+# All services in one VM
+
+variable "all_in_one_node_count" {
+  type    = number
+  default = 0
+}
+
+variable "all_in_one_machine_type" {
+  type    = string
+  default = "e2-standard-2"
+}
+
+variable "all_in_one_machine_image" {
+  type    = string
+  default = "debian-cloud/debian-11"
+}
+
+variable "all_in_one_boot_disk_size" {
+  type    = number
+  default = 10
+}
+
+variable "all_in_one_disk_count" {
+  type    = number
+  default = 0
+}
+
+variable "all_in_one_disk_size" {
+  type    = number
+  default = 300
+}
+
+variable "all_in_one_disk_type" {
+  type    = string
+  default = "pd-standard"
+}
+
+variable "all_in_one_disk_attach" {
+  type        = string
+  description = "Instance ID to attach MariaDB disk"
+  default     = ""
+}
+
+variable "all_in_one_disk_snapshot" {
+  type = string
+  description = "The source snapshot used to create this disk"
+  default = null
+}
+
+variable "all_in_one_ansible_use_external_ip" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
We have one VM for each BAP service:

- MariaDB
- Redis
- OpenSearch
- OpenSearch Dashboards
- SortingHat
- SortingHat Workers
- Nginx
- Mordred

The goal is to provide the option to deploy all BAP services in a single VM.
