### PR TITLE
[opensearch] Add Audit Log configuration

### DIFF
--- a/ansible/roles/opensearch/defaults/main.yml
+++ b/ansible/roles/opensearch/defaults/main.yml
@@ -82,6 +82,27 @@ opensearch_snapshots_cronjob_time:
 opensearch_snapshots_script: /usr/local/bin/make_snapshot.sh
 opensearch_snapshots_json_file: "{{ opensearch_workdir }}/snapshot.json"
 
+# Audit Log
+opensearch_auditlog_enabled: true
+opensearch_auditlog_ingore_users: ["kibanaserver"]
+opensearch_auditlog_ignore_requests: ["/_mget*", "/_plugins*", "/_template", "/_search", "/_mapping*", "/_cat*", "/_alias*", "/_cluster*", "/.kibana/_search", "/.kibana/_doc/config*", "/_resolve*"]
+opensearch_auditlog_disabled_rest_categories: ["GRANTED_PRIVILEGES", "BAD_HEADERS", "FAILED_LOGIN", "MISSING_PRIVILEGES", "SSL_EXCEPTION"]
+opensearch_auditlog_disabled_transport_categories: ["GRANTED_PRIVILEGES", "BAD_HEADERS", "FAILED_LOGIN", "MISSING_PRIVILEGES", "SSL_EXCEPTION", "INDEX_EVENT", "OPENDISTRO_SECURITY_INDEX_ATTEMPT"]
+opensearch_auditlog_log_request_body: false
+opensearch_auditlog_resolve_indices: false
+opensearch_auditlog_resolve_bulk_requests: false
+opensearch_auditlog_exclude_sensitive_headers: false
+opensearch_auditlog_enable_transport: false
+opensearch_auditlog_enable_rest: true
+opensearch_auditlog_compliance_enabled: true
+opensearch_auditlog_compliance_write_log_diffs: false
+opensearch_auditlog_compliance_read_watched_fields: {}
+opensearch_auditlog_compliance_write_watched_indices: []
+opensearch_auditlog_compliance_read_metadata_only: false
+opensearch_auditlog_compliance_opensearch_auditlog_write_metadata_only: true
+opensearch_auditlog_compliance_external_config: false
+opensearch_auditlog_compliance_internal_config: true
+
 ## Google Cloud Credendials
 opensearch_keys_dir:  "{{ opensearch_workdir }}/keys"
 gcp_service_account_file: "{{ opensearch_keys_dir }}/gcs_credentials.json"

--- a/ansible/roles/opensearch/tasks/security_admin.yml
+++ b/ansible/roles/opensearch/tasks/security_admin.yml
@@ -49,3 +49,54 @@
     dest: "{{ opensearch_workdir }}/security_initialized"
     mode: 0400
     force: false
+
+- name: Create Audit Log ingore users
+  set_fact:
+    opensearch_auditlog_ingore_users: |-
+      [
+      {% for item in instances %}
+        "{{ item.project }}_mordred",
+      {% endfor %}
+        "kibanaserver"
+      ]
+  when: opensearch_auditlog_enabled
+
+- name: Check Audit Log ingore users
+  debug:
+    msg: "{{ opensearch_auditlog_ingore_users }}"
+  when: opensearch_auditlog_enabled
+
+- name: Configure security Audit Log
+  uri:
+    url: "{{ opensearch_endpoint }}/_opendistro/_security/api/audit/config"
+    method: PUT
+    body_format: json
+    body:
+      enabled: "{{ opensearch_auditlog_enabled }}"
+      audit:
+        ignore_users: "{{ opensearch_auditlog_ingore_users }}"
+        ignore_requests: "{{ opensearch_auditlog_ignore_requests }}"
+        disabled_rest_categories: "{{ opensearch_auditlog_disabled_rest_categories }}"
+        disabled_transport_categories: "{{ opensearch_auditlog_disabled_transport_categories }}"
+        log_request_body: "{{ opensearch_auditlog_log_request_body }}"
+        resolve_indices: "{{ opensearch_auditlog_resolve_indices }}"
+        resolve_bulk_requests: "{{ opensearch_auditlog_resolve_bulk_requests }}"
+        exclude_sensitive_headers: "{{ opensearch_auditlog_exclude_sensitive_headers }}"
+        enable_transport: "{{ opensearch_auditlog_enable_transport }}"
+        enable_rest: "{{ opensearch_auditlog_enable_rest }}"
+      compliance:
+        enabled: "{{ opensearch_auditlog_compliance_enabled }}"
+        write_log_diffs: "{{ opensearch_auditlog_compliance_write_log_diffs }}"
+        read_watched_fields: "{{ opensearch_auditlog_compliance_read_watched_fields }}"
+        read_ignore_users: "{{ opensearch_auditlog_ingore_users }}"
+        write_watched_indices: "{{ opensearch_auditlog_compliance_write_watched_indices }}"
+        write_ignore_users: "{{ opensearch_auditlog_ingore_users }}"
+        read_metadata_only: "{{ opensearch_auditlog_compliance_read_metadata_only }}"
+        write_metadata_only: "{{ opensearch_auditlog_compliance_opensearch_auditlog_write_metadata_only }}"
+        external_config: "{{ opensearch_auditlog_compliance_external_config }}"
+        internal_config: "{{ opensearch_auditlog_compliance_internal_config }}"
+    client_cert: "{{ certs_dir }}/{{ certs_files.admin_cert }}"
+    client_key: "{{ certs_dir }}/{{ certs_files.admin_key }}"
+    validate_certs: false
+  run_once: true
+  when: opensearch_auditlog_enabled

--- a/ansible/roles/opensearch/templates/opensearch.yml.j2
+++ b/ansible/roles/opensearch/templates/opensearch.yml.j2
@@ -20,7 +20,9 @@ plugins.security.authcz.admin_dn:
   - "{{ certs_dn.admin_cert }}"
 plugins.security.nodes_dn:
   - "{{ certs_dn.node_cert }}"
+{% if opensearch_auditlog_enabled %}
 plugins.security.audit.type: internal_opensearch
+{% endif %}
 plugins.security.enable_snapshot_restore_privilege: true
 plugins.security.check_snapshot_restore_write_privileges: true
 plugins.security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]


### PR DESCRIPTION
This commit configures the Audit Log with the following parameters:

- Category: `AUTHENTICATED`
- Ignored users: kibanaserver and Mordred users
- Ignored requests:
  - /_mget*
  - /_plugins*
  - /_template
  - /_search
  - /_mapping*
  - /_cat*
  - /_alias*
  - /_cluster*
  - /.kibana/_search
  - /.kibana/_doc/config*
  - /_resolve*