### PR TITLE
[opensearch] Create OpenSearch Security backup

### DIFF
--- a/ansible/roles/opensearch/defaults/main.yml
+++ b/ansible/roles/opensearch/defaults/main.yml
@@ -103,6 +103,15 @@ opensearch_auditlog_compliance_opensearch_auditlog_write_metadata_only: true
 opensearch_auditlog_compliance_external_config: false
 opensearch_auditlog_compliance_internal_config: true
 
+# OpenSearch Security backup
+opensearch_security_dir: "{{ opensearch_workdir }}/opensearch-security"
+opensearch_security_backup_dir: "{{ opensearch_security_dir }}/backup"
+opensearch_security_backup_script: "{{ opensearch_security_dir }}/opensearch_security_backup.sh"
+opensearch_security_backup_cronjob_time: "daily" # "annually", "daily", "hourly", "monthly", "reboot", "weekly", "yearly"
+## Restore from backup
+opensearch_security_backup_restore: false
+#opensearch_security_backup_restore_name: opensearch-security-backup_20240701.tgz # opensearch-security-backup_%Y%m%d.tgz
+
 ## Google Cloud Credendials
 opensearch_keys_dir:  "{{ opensearch_workdir }}/keys"
 gcp_service_account_file: "{{ opensearch_keys_dir }}/gcs_credentials.json"

--- a/ansible/roles/opensearch/tasks/main.yml
+++ b/ansible/roles/opensearch/tasks/main.yml
@@ -14,6 +14,13 @@
     mode: 0750
     recurse: true
 
+- name: Copy gsutil credentials file
+  template:
+    src: boto.j2
+    dest: ~/.boto
+    mode: 0500
+    owner: "{{ ansible_user_id }}"
+
 - name: Configure OpenSearch certificates
   import_tasks: certificates.yml
 
@@ -39,6 +46,15 @@
     owner: '1000'
     group: '1000'
     mode: 0660
+
+- name: Create OpenSearch Security files
+  file:
+    path: "{{ opensearch_security_backup_dir }}"
+    state: directory
+    owner: '1000'
+    group: '1000'
+    mode: 0660
+    recurse: true
 
 - name: Configure OpenSearch security
   import_tasks: security_config.yml
@@ -85,9 +101,10 @@
       - "{{ certs_dir }}/{{ certs_files.node_key }}:/usr/share/opensearch/config/{{ certs_files.node_key }}"
       - "{{ opensearch_workdir }}/opensearch.yml:/usr/share/opensearch/config/opensearch.yml"
       - "{{ opensearch_workdir }}/log4j2.properties:/usr/share/opensearch/config/log4j2.properties"
-      - "{{ opensearch_workdir }}/opensearch-security/config.yml:/usr/share/opensearch/config/opensearch-security/config.yml"
-      - "{{ opensearch_workdir }}/opensearch-security/internal_users.yml:/usr/share/opensearch/config/opensearch-security/internal_users.yml"
-      - "{{ opensearch_workdir }}/opensearch-security/roles_mapping.yml:/usr/share/opensearch/config/opensearch-security/roles_mapping.yml"
+      - "{{ opensearch_security_dir }}/config.yml:/usr/share/opensearch/config/opensearch-security/config.yml"
+      - "{{ opensearch_security_dir }}/internal_users.yml:/usr/share/opensearch/config/opensearch-security/internal_users.yml"
+      - "{{ opensearch_security_dir }}/roles_mapping.yml:/usr/share/opensearch/config/opensearch-security/roles_mapping.yml"
+      - "{{ opensearch_security_backup_dir }}:/tmp/backup/"
       - "{{ opensearch_logs_dir }}:/usr/share/opensearch/logs"
     ports:
       - "{{ network.publish_host }}:9200:9200"
@@ -103,6 +120,9 @@
 
 - name: Init OpenSearch security plugin
   import_tasks: security_admin.yml
+
+- name: Configure OpenSearch Security Backup
+  import_tasks: security_backup.yml
 
 - name: Set default template for indices
   uri:

--- a/ansible/roles/opensearch/tasks/restore_security_backup.yml
+++ b/ansible/roles/opensearch/tasks/restore_security_backup.yml
@@ -1,0 +1,57 @@
+---
+- name: Download OpenSearch Security backup from GCP bucket
+  command: >
+    gsutil cp -P gs://{{ backups_assets_bucket }}/opensearch-security-backup/{{ opensearch_security_backup_restore_name }}
+    {{ opensearch_security_dir }}/{{ opensearch_security_backup_restore_name }}
+
+- name: Empty OpenSearch Security backup directory
+  shell: rm -rf {{ opensearch_security_backup_dir }}/*
+
+- name: Unarchive OpenSearch Security backup file (.tgz)
+  unarchive:
+    src: "{{ opensearch_security_dir }}/{{ opensearch_security_backup_restore_name }}"
+    dest: "{{ opensearch_security_backup_dir }}"
+    extra_opts:
+    - --transform
+    - s/security_tenants/tenants/
+    remote_src: yes
+
+- name: Rename OpenSearch Security files removing date
+  shell: >
+    find {{ opensearch_security_backup_dir }}/ -regextype sed
+    -regex '.*/{{ item }}_[0-9]\{4\}-[a-zA-Z]\{3\}-[0-9]\{2\}_[0-9]\{2\}-[0-9]\{2\}-[0-9]\{2\}.yml'
+    -exec mv '{}' {{ opensearch_security_backup_dir }}/{{ item }}.yml \;
+  with_items:
+  - action_groups
+  - allowlist
+  - audit
+  - config
+  - internal_users
+  - nodes_dn
+  - roles
+  - roles_mapping
+  - tenants
+  - whitelist
+
+- name: Run securityadmin.sh to restore OpenSearch Security files
+  command: >
+    docker exec {{ opensearch_docker_container }}
+    bash plugins/opensearch-security/tools/securityadmin.sh
+    -cd /tmp/backup/
+    -cacert config/{{ certs_files.ca_cert }}
+    -cert config/{{ certs_files.admin_cert }}
+    -key config/{{ certs_files.admin_key }}
+    -icl -nhnv
+  register: securityadmin_restore
+  changed_when: false
+  until: securityadmin.rc == 0
+  retries: 10
+  delay: 10
+  any_errors_fatal: true
+  run_once: true
+
+- name: Show securityadmin_restore output
+  debug:
+    msg: "{{ securityadmin_restore.stdout }}"
+  run_once: true
+

--- a/ansible/roles/opensearch/tasks/security_backup.yml
+++ b/ansible/roles/opensearch/tasks/security_backup.yml
@@ -1,0 +1,25 @@
+---
+
+- name: Copy OpenSearch Security backup script and gsutil credentials (~/.boto)
+  template:
+    src: "{{ item.src }}"
+    dest: "{{item.dest }}"
+    mode: 0500
+    owner: "{{ ansible_user_id }}"
+  with_items:
+    - src: opensearch-security/backup.sh.j2
+      dest: "{{ opensearch_security_backup_script }}"
+    - src: boto.j2
+      dest: ~/.boto
+
+- name: Create cron job for OpenSearch Security backup
+  cron:
+    name: "Make OpenSearch Security backup"
+    user: "{{ ansible_user_id }}"
+    special_time: "{{ opensearch_security_backup_cronjob_time }}"
+    job: "{{ opensearch_security_backup_script }}"
+
+- name: Restore OpenSearch Security backup
+  import_tasks: restore_security_backup.yml
+  when: opensearch_security_backup_restore
+

--- a/ansible/roles/opensearch/tasks/security_config.yml
+++ b/ansible/roles/opensearch/tasks/security_config.yml
@@ -2,7 +2,7 @@
 
 - name: Create OpenSearch security directory
   file:
-    path: "{{ opensearch_workdir }}/opensearch-security"
+    path: "{{ opensearch_security_dir }}"
     state: directory
     mode: 0775
     recurse: true

--- a/ansible/roles/opensearch/tasks/snapshots.yml
+++ b/ansible/roles/opensearch/tasks/snapshots.yml
@@ -51,13 +51,6 @@
   ignore_errors: true
   changed_when: false
 
-- name: Delete credentials file
-  file:
-    path: "{{ gcp_service_account_file }}"
-    state: absent
-  ignore_errors: true
-  changed_when: false
-
 - name: "Create snapshot repository '{{ opensearch_snapshots_repository }}'"
   uri:
     url: "{{ opensearch_snapshots_url }}/_snapshot/{{ opensearch_snapshots_repository }}"
@@ -118,12 +111,16 @@
     mode: 0500
     owner: "{{ ansible_user_id }}"
 
-- name: Create cron job
+- name: Create cron job for OpenSearch snapshot
   cron:
-    name: "Make ES snapshot"
+    name: "Make OpenSearch snapshot"
     user: "{{ ansible_user_id }}"
     hour: "{{ opensearch_snapshots_cronjob_time.hour }}"
     minute: "{{ opensearch_snapshots_cronjob_time.minute }}"
     weekday: "{{ opensearch_snapshots_cronjob_time.weekday }}"
     job: "{{ opensearch_snapshots_script }}"
     backup: true
+
+- name: Empty OpenSearch Security backup directory
+  shell: rm -rf {{ opensearch_security_backup_dir }}/*
+  when: not opensearch_security_backup_restore

--- a/ansible/roles/opensearch/templates/boto.j2
+++ b/ansible/roles/opensearch/templates/boto.j2
@@ -1,0 +1,2 @@
+[Credentials]
+gs_service_key_file={{ gcp_service_account_file }}

--- a/ansible/roles/opensearch/templates/opensearch-security/backup.sh.j2
+++ b/ansible/roles/opensearch/templates/opensearch-security/backup.sh.j2
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+DATE=$(date "+%Y%m%d")
+BACKUP_DIR="{{ opensearch_security_dir }}"
+BACKUP_NAME="opensearch-security-backup_${DATE}.tgz"
+
+# Empty the backup directory
+rm -rf {{ opensearch_security_backup_dir }}/*
+
+# Create a new backup files
+docker exec {{ opensearch_docker_container }} \
+    bash plugins/opensearch-security/tools/securityadmin.sh \
+    -cacert config/{{ certs_files.ca_cert }} \
+    -cert config/{{ certs_files.admin_cert }} \
+    -key config/{{ certs_files.admin_key }} \
+    -icl -nhnv -cd /tmp/backup -r
+
+# Compress backup directory
+tar -cvzf ${BACKUP_DIR}/${BACKUP_NAME} -C "{{ opensearch_security_backup_dir }}" .
+
+# Upload the new backup to GCP bucket
+gsutil cp ${BACKUP_DIR}/${BACKUP_NAME} "gs://{{ backups_assets_bucket }}/opensearch-security-backup/${BACKUP_NAME}"

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -109,6 +109,9 @@ all:
     opensearch_cluster_prefix: <opensearch_cluster_prefix>
     opensearch_cluster_name: <opensearch_cluster_name>
     opensearch_cluster_heap_size: <opensearch_cluster_heap_size>
+    ## Uncomment to restore OpenSearch Security files from a backup
+    # opensearch_security_backup_restore: true
+    # opensearch_security_backup_restore_name: opensearch-security-backup_20241018.tgz
 
     ## OpenSearch Credentials
     opensearch_admin_user: <admin_username>
@@ -368,6 +371,19 @@ Replace the entries in `<>` with your values:
 
 - `mordred_ssh_key.private`: path to your SSH private key file
 - `mordred_ssh_key.public`: path to your SSH public key file
+
+#### Restore OpenSearch Security from a backup (optional)
+
+Toolkit will create a backup daily by default, if you want to restore the
+OpenSearch Security files from a backup add these parameters. Click [here](https://opensearch.org/docs/latest/security/configuration/security-admin/)
+for more information.
+
+- `opensearch_security_backup_restore`: Restore from a backup (by default is `false`)
+- `opensearch_security_backup_restore_name`: The name of the backup to restore
+  with the format `opensearch-security-backup_%Y%m%d.tgz` (e.g. `opensearch-security-backup_20241018.tgz`).
+- `opensearch_security_backup_cronjob_time`: The frequency of the backup, here are the
+  choices: `annually`, `daily`, `hourly`, `monthly`, `reboot`, `weekly`, and `yearly`
+  (by default is `daily`).
 
 ## 3. Setup Ansible Authentication
 


### PR DESCRIPTION
This commit creates OpenSearch Security daily backup and uploads them to a GCP bucket, it also allows the restoration of these files configurating `opensearch_security_backup_restore` and `opensearch_security_backup_restore_name` parameters.

docs/deployment_and_config.md updated accordingly.