### PR TITLE
[sortinghat] Fix subdomain regex

### DIFF
--- a/ansible/roles/sortinghat/tasks/main.yml
+++ b/ansible/roles/sortinghat/tasks/main.yml
@@ -172,7 +172,7 @@
       [
       {% for item in allowed_hosts %}
         {{ "" if loop.first else "," }}
-        "{{ item | regex_replace('^\.(.*)\.(.*)', '^https?://([a-zA-Z0–9-]+\.)+\1\.\2$') }}"
+        "{{ item | regex_replace('^\.(.*)\.(.*)', '^https?://([a-zA-Z0-9_-]+\.)+\1\.\2$') }}"
       {% endfor %}
       ]
 


### PR DESCRIPTION
This commit fixes the regex to include numbers and `_` in `sortinghat_cors_allowed_origins_regexes`.