### PR TITLE
[nginx] Improve certbot renew tasks

### DIFF
--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -42,6 +42,9 @@ nginx_letsencrypt_workdir: "{{ nginx_workdir }}/letsencrypt"
 nginx_letsencrypt_logsdir: "{{ nginx_letsencrypt_workdir }}/logs"
 nginx_letsencrypt_configdir: "{{ nginx_letsencrypt_workdir }}/config"
 nginx_letsencrypt_webroot_path: "{{ nginx_letsencrypt_workdir }}/webroot"
+nginx_letsencrypt_cert_warning_days: 30
+nginx_letsencrypt_certbot_renew_script_dest: "{{ nginx_letsencrypt_workdir }}/certbot_renew.sh"
+nginx_letsencrypt_cronjob_time: "daily" # "annually", "daily", "hourly", "monthly", "reboot", "weekly", "yearly"
 
 ## Custom certifications
 nginx_certs_dir: "{{ nginx_workdir }}/certs"

--- a/ansible/roles/nginx/tasks/certbot.yml
+++ b/ansible/roles/nginx/tasks/certbot.yml
@@ -6,23 +6,39 @@
     executable: pip3
 
 - name: Register certbot
+  run_once: true
   shell: |
     certbot -n register --agree-tos --email {{ letsencrypt_register_email }} --work-dir {{ nginx_letsencrypt_workdir }} --logs-dir {{ nginx_letsencrypt_logsdir }} --config-dir {{ nginx_letsencrypt_configdir }}
     touch {{ nginx_letsencrypt_workdir }}/.registered
   args:
     creates: "{{ nginx_letsencrypt_workdir }}/.registered"
 
-- name: Get certificate
+- name: "Get {{ hostname }} certificate info"
+  shell: openssl x509 -in "{{ nginx_letsencrypt_configdir }}/live/{{ hostname }}/cert.pem" -noout -dates | awk -F= '/notAfter=/ {print $2}'
+  register: cert_info
+
+- name: "Show {{ hostname }} certificate info"
+  debug:
+    msg: "{{ cert_info }}"
+
+- name: "Create certificate for {{ hostname }}"
   command: "certbot -n certonly --webroot -w {{ nginx_letsencrypt_webroot_path }} -d {{ hostname }} --work-dir {{ nginx_letsencrypt_workdir }} --logs-dir {{ nginx_letsencrypt_logsdir }} --config-dir {{ nginx_letsencrypt_configdir }}"
   args:
     creates: "{{ nginx_letsencrypt_workdir }}/live/{{ hostname }}"
   ignore_errors: true
+  when: cert_info.stderr
 
-- name: Setup cronjob for renewal (At 00:00 on day-of-month 1 in every 2nd month, Let's Encrypt certificates expire in 90 days)
+- name: Copy renew Cerbot script
+  run_once: true
+  template:
+    src: certbot_renew.sh.j2
+    dest: "{{ nginx_letsencrypt_certbot_renew_script_dest }}"
+    mode: 0500
+    owner: "{{ ansible_user_id }}"
+
+- name: Setup cronjob for renewal (Let's Encrypt certificates expire in 90 days)
+  run_once: true
   cron:
-    name: certbot-renewal (At 00:00 on day-of-month 1 in every 2nd month)
-    job: "certbot -q renew --work-dir {{ nginx_letsencrypt_workdir }} --logs-dir {{ nginx_letsencrypt_logsdir }} --config-dir {{ nginx_letsencrypt_configdir }}"
-    month: "*/2"
-    day: "1"
-    hour: "0"
-    minute: "0"
+    name: Certbot renewal
+    job: "{{ nginx_letsencrypt_certbot_renew_script_dest }}"
+    special_time: "{{ nginx_letsencrypt_cronjob_time }}"

--- a/ansible/roles/nginx/templates/certbot_renew.sh.j2
+++ b/ansible/roles/nginx/templates/certbot_renew.sh.j2
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+CERTBOT_CONFIG_DIR="{{ nginx_letsencrypt_configdir }}"
+CERTBOT_CERTS_DIR="{{ nginx_letsencrypt_configdir }}/live"
+CERTBOT_WORK_DIR="{{ nginx_letsencrypt_workdir }}"
+CERTBOT_LOGS_DIR="{{ nginx_letsencrypt_logsdir }}"
+CERTBOT_OUTPUT="{{ nginx_letsencrypt_logsdir }}/certbot_renew.log"
+
+WARNING_DAYS="{{ nginx_letsencrypt_cert_warning_days }}"
+
+DATE_NOW=$(date +"%Y-%m-%d %H:%M:%S")
+
+# Function to check certs
+renew_cert() {
+    cert_path="$CERTBOT_CERTS_DIR/$1/cert.pem"
+    if [ ! -f "$cert_path" ]; then
+        echo "$DATE_NOW - $1: 'cert.pem' not found at $CERTBOT_CERTS_DIR/$1/" >> "$CERTBOT_OUTPUT"
+        return 1
+    fi
+
+    expiry_date=$(openssl x509 -in "$cert_path" -noout -dates | awk -F= '/notAfter=/ {print $2}')
+    expiry_date=$(date -d "$expiry_date" +"%b %d %H:%M:%S %Y %Z")
+    days_left=$(((`date -d "$expiry_date" +%s`-`date -d "now" +%s`)/(60*60*24)))
+
+    if [ "$days_left" -lt "$WARNING_DAYS" ]; then
+        echo "$DATE_NOW - $1: Expires in $days_left days. Renewing cert" >> $CERTBOT_OUTPUT
+        certbot -q renew --work-dir $CERTBOT_WORK_DIR --logs-dir $CERTBOT_LOGS_DIR --config-dir $CERTBOT_CONFIG_DIR
+        if [ $? -eq 0 ]; then
+            echo "$DATE_NOW - $1: Cert renewed" >> $CERTBOT_OUTPUT
+            docker restart "{{ nginx_docker_container }}"
+        else
+            echo "$DATE_NOW - $1: ERROR cert not renewed" >> $CERTBOT_OUTPUT
+        fi
+    else
+        echo "$DATE_NOW - $1: Still valid. It expires on $expiry_date" >> $CERTBOT_OUTPUT
+    fi
+}
+
+for cert_dir in "$CERTBOT_CERTS_DIR"/*; do
+    if [ -d "$cert_dir" ]; then
+        domain=$(basename "$cert_dir")
+        renew_cert "$domain"
+    fi
+done


### PR DESCRIPTION
This code creates new certificates if they do not exist and the
crontab script checks daily if the certificates are still valid
and renew them if necessary. By default, if the expiration time
is less than 30 days, it will be renewed (it can be changed by
setting the `nginx_letsencrypt_cert_warning_days` parameter).
