### PR TITLE
[sortinghat_worker] Fix host (ansible_default_ipv4.address)

### DIFF
--- a/ansible/roles/sortinghat_worker/tasks/main.yml
+++ b/ansible/roles/sortinghat_worker/tasks/main.yml
@@ -74,7 +74,7 @@
 - name: Create MariaDB service account for SortingHat worker
   mysql_user:
     name: "{{ mariadb_service_account }}"
-    host: "{{ '172.%' if 'all_in_one' in groups else ansible_all_ipv4_addresses }}"
+    host: "{{ '172.%' if 'all_in_one' in groups else ansible_default_ipv4.address }}"
     password: "{{ mariadb_service_account_password }}"
     priv: "{{ privileges }}"
     login_user: root


### PR DESCRIPTION
This commit fixes the host at create MariaDB service account task. The `ansible_all_ipv4_addresses` value is a list of all addressess instead of the main IP (`ansible_default_ipv4.address`).