### PR TITLE
[opensearch] Remove MIME type header in the security backup

### DIFF
--- a/ansible/roles/opensearch/templates/opensearch-security/backup.sh.j2
+++ b/ansible/roles/opensearch/templates/opensearch-security/backup.sh.j2
@@ -16,7 +16,8 @@ docker exec {{ opensearch_docker_container }} \
     -icl -nhnv -cd /tmp/backup -r
 
 # Compress backup directory
-tar -cvzf ${BACKUP_DIR}/${BACKUP_NAME} -C "{{ opensearch_security_backup_dir }}" .
+cd "{{ opensearch_security_backup_dir }}"
+tar -cvzf ${BACKUP_DIR}/${BACKUP_NAME} *.yml
 
 # Upload the new backup to GCP bucket
-gsutil cp ${BACKUP_DIR}/${BACKUP_NAME} "gs://{{ backups_assets_bucket }}/opensearch-security-backup/${BACKUP_NAME}"
+gsutil -h 'Content-Type:' cp ${BACKUP_DIR}/${BACKUP_NAME} "gs://{{ backups_assets_bucket }}/opensearch-security-backup/${BACKUP_NAME}"


### PR DESCRIPTION
This commit removes the MIME type header from the OpenSearch security compressed backup (tgz) file in the upload process to the GCP bucket.