### PR TITLE
Add logrotate to Nginx docker container

### DIFF
--- a/ansible/roles/nginx/files/logrotate.conf
+++ b/ansible/roles/nginx/files/logrotate.conf
@@ -1,0 +1,23 @@
+# see "man logrotate" for details
+
+# global options do not affect preceding include directives
+
+# rotate log files weekly
+weekly
+
+# keep 4 weeks worth of backlogs
+rotate 4
+
+# create new (empty) log files after rotating old ones
+create
+
+# use date as a suffix of the rotated file
+#dateext
+
+# uncomment this if you want your log files compressed
+#compress
+
+# packages drop log rotation information into this directory
+include /etc/logrotate.d
+
+# system-specific logs may also be configured here.

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -1,5 +1,22 @@
 ---
 
+- name: Install logrotate
+  package:
+    name: logrotate
+    state: present
+
+- name: Copy logrotate.conf to /etc/logrotate.conf
+  copy:
+    src: "{{ role_path }}/files/logrotate.conf"
+    dest: /etc/logrotate.conf
+    mode: "0644"
+
+- name: Generate /etc/logrotate.d/nginx
+  template:
+    src: nginx_logrotate.j2
+    dest: /etc/logrotate.d/nginx
+    mode: "0644"
+
 - name: Remove old NGINX container
   docker_container:
     name: "{{ nginx_docker_container }}"

--- a/ansible/roles/nginx/templates/nginx_logrotate.j2
+++ b/ansible/roles/nginx/templates/nginx_logrotate.j2
@@ -1,0 +1,12 @@
+{{ nginx_log_dir }}/*.log
+{
+    su root root
+    rotate 7
+    size 5M
+    missingok
+    notifempty
+    delaycompress
+    compress
+    create 0640
+    copytruncate
+}

--- a/ansible/roles/sortinghat/defaults/main.yml
+++ b/ansible/roles/sortinghat/defaults/main.yml
@@ -75,6 +75,7 @@ nginx_docker_container: nginx
 ## Node configuration
 nginx_workdir: /docker/nginx
 nginx_virtualhosts_workdir: "{{ nginx_workdir }}/conf"
+nginx_log_dir: "{{ nginx_workdir }}/log"
 
 ## Enable SSL
 enable_ssl: False

--- a/ansible/roles/sortinghat/files/logrotate.conf
+++ b/ansible/roles/sortinghat/files/logrotate.conf
@@ -1,0 +1,23 @@
+# see "man logrotate" for details
+
+# global options do not affect preceding include directives
+
+# rotate log files weekly
+weekly
+
+# keep 4 weeks worth of backlogs
+rotate 4
+
+# create new (empty) log files after rotating old ones
+create
+
+# use date as a suffix of the rotated file
+#dateext
+
+# uncomment this if you want your log files compressed
+#compress
+
+# packages drop log rotation information into this directory
+include /etc/logrotate.d
+
+# system-specific logs may also be configured here.

--- a/ansible/roles/sortinghat/tasks/nginx.yml
+++ b/ansible/roles/sortinghat/tasks/nginx.yml
@@ -1,5 +1,22 @@
 ---
 
+- name: Install logrotate
+  package:
+    name: logrotate
+    state: present
+
+- name: Copy logrotate.conf to /etc/logrotate.conf
+  copy:
+    src: "{{ role_path }}/files/logrotate.conf"
+    dest: /etc/logrotate.conf
+    mode: "0644"
+
+- name: Generate /etc/logrotate.d/nginx
+  template:
+    src: nginx_logrotate.j2
+    dest: /etc/logrotate.d/nginx
+    mode: "0644"
+
 - name: Configure virtualhost(s)
   include_tasks: virtualhost.yml
 
@@ -31,6 +48,7 @@
     image: "{{ nginx_docker_image }}:{{ nginx_version }}"
     volumes:
       - "{{ nginx_virtualhosts_workdir}}:/etc/nginx/conf.d/"
+      - "{{ nginx_log_dir }}:/var/log/nginx"
       - "{{ certs_dir }}/{{ ansible_hostname }}.crt:/etc/ssl/certs/{{ ansible_hostname }}.crt"
       - "{{ certs_dir }}/{{ ansible_hostname }}.key:/etc/ssl/private/{{ ansible_hostname }}.key"
     ports:

--- a/ansible/roles/sortinghat/templates/nginx_logrotate.j2
+++ b/ansible/roles/sortinghat/templates/nginx_logrotate.j2
@@ -1,0 +1,12 @@
+{{ nginx_log_dir }}/*.log
+{
+    su root root
+    rotate 7
+    size 5M
+    missingok
+    notifempty
+    delaycompress
+    compress
+    create 0640
+    copytruncate
+}


### PR DESCRIPTION
This commit adds the `logrotate` setting to Nginx because log files could fill the disk.