### PR TITLE
[docker] Add max-size log options to all docker containers

### DIFF
--- a/ansible/roles/mariadb/defaults/main.yml
+++ b/ansible/roles/mariadb/defaults/main.yml
@@ -48,3 +48,4 @@ mariadb_backup_script: /usr/local/bin/mariadb_backup.sh
 mariadb_innodb_buffer_pool_size: 6871947673
 
 docker_network_name: bap_network
+docker_log_max_size: 500m

--- a/ansible/roles/mariadb/tasks/main.yml
+++ b/ansible/roles/mariadb/tasks/main.yml
@@ -50,6 +50,9 @@
     volumes:
       - mariadb_data:/var/lib/mysql
       - "{{ mariadb_logs_dir }}:/var/log/mysql/"
+    log_driver: json-file
+    log_options:
+      max-size: "{{ docker_log_max_size }}"
   register: result
   retries: 2
   delay: 5

--- a/ansible/roles/mordred/defaults/main.yml
+++ b/ansible/roles/mordred/defaults/main.yml
@@ -38,3 +38,4 @@ mariadb_hosts: "{{ groups['all_in_one'][0] | default(groups['mariadb'][0]) }}"
 opensearch_host: "{{ groups['all_in_one'][0] | default(groups['opensearch'][0]) }}"
 
 docker_network_name: bap_network
+docker_log_max_size: 500m

--- a/ansible/roles/mordred/tasks/main.yml
+++ b/ansible/roles/mordred/tasks/main.yml
@@ -44,6 +44,9 @@
     - "{{ mordred_instances_dir }}/{{ item.project }}/sources/:/home/grimoire/data-sources/"
     - "{{ mordred_instances_dir }}/{{ item.project }}/logs/:/home/grimoire/logs/"
     - "{{ mordred_instances_dir }}/{{ item.project }}/perceval-cache/:/home/grimoire/.perceval/"
+    log_driver: json-file
+    log_options:
+      max-size: "{{ docker_log_max_size }}"
   with_items:
     - "{{ instances }}"
   delegate_to: "{{ groups['all_in_one'][0] | default(groups['mordred'][item.mordred.host]) }}"

--- a/ansible/roles/nginx/defaults/main.yml
+++ b/ansible/roles/nginx/defaults/main.yml
@@ -72,3 +72,4 @@ gcloud_apt_deb_ubuntu_repository: >-
   https://packages.cloud.google.com/apt cloud-sdk main
 
 docker_network_name: bap_network
+docker_log_max_size: 500m

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -81,6 +81,9 @@
     exposed_ports:
       - "80"
       - "443"
+    log_driver: json-file
+    log_options:
+      max-size: "{{ docker_log_max_size }}"
   when: custom_cert is undefined
 
 - name: Configure virtualhost(s) for all instances
@@ -105,6 +108,9 @@
     exposed_ports:
       - "80"
       - "443"
+    log_driver: json-file
+    log_options:
+      max-size: "{{ docker_log_max_size }}"
 
 - name: Launch first rsync
   shell: gsutil -m rsync -d -r "gs://{{ sortinghat_assets_bucket }}/" "{{ nginx_gcs_workdir }}"

--- a/ansible/roles/opensearch/defaults/main.yml
+++ b/ansible/roles/opensearch/defaults/main.yml
@@ -118,3 +118,4 @@ gcp_service_account_file: "{{ opensearch_keys_dir }}/gcs_credentials.json"
 gcs_cred_file_container: "/usr/share/opensearch/config/gcs_credentials.json"
 
 docker_network_name: bap_network
+docker_log_max_size: 500m

--- a/ansible/roles/opensearch/tasks/main.yml
+++ b/ansible/roles/opensearch/tasks/main.yml
@@ -117,6 +117,9 @@
       - "9200"
       - "9300"
       - "9600"
+    log_driver: json-file
+    log_options:
+      max-size: "{{ docker_log_max_size }}"
 
 - name: Init OpenSearch security plugin
   import_tasks: security_admin.yml

--- a/ansible/roles/opensearch_dashboards/defaults/main.yml
+++ b/ansible/roles/opensearch_dashboards/defaults/main.yml
@@ -67,3 +67,4 @@ opensearch_dashboards_cert_fqdn: opensearch.example.org
 # opensearch_dashboards_multiple_auth: true
 
 docker_network_name: bap_network
+docker_log_max_size: 500m

--- a/ansible/roles/opensearch_dashboards/tasks/main.yml
+++ b/ansible/roles/opensearch_dashboards/tasks/main.yml
@@ -53,6 +53,9 @@
       - "{{ opensearch_dashboards_workdir }}/opensearch_dashboards.yml:/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml"
     ports:
       - "{{ network.bind_host }}:5601:5601"
+    log_driver: json-file
+    log_options:
+      max-size: "{{ docker_log_max_size }}"
   delegate_to: "{{ groups['opensearch_dashboards'][0] }}"
   when: "'opensearch_dashboards' in groups and inventory_hostname in groups['opensearch_dashboards']"
 
@@ -70,6 +73,9 @@
       - "{{ opensearch_dashboards_workdir }}/opensearch_dashboards.yml:/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml"
     ports:
       - "{{ network.bind_host }}:5601:5601"
+    log_driver: json-file
+    log_options:
+      max-size: "{{ docker_log_max_size }}"
   delegate_to: "{{ groups['opensearch_dashboards_anonymous'][0] }}"
   when: "'opensearch_dashboards_anonymous' in groups and inventory_hostname in groups['opensearch_dashboards_anonymous']"
 
@@ -87,4 +93,7 @@
       - "{{ opensearch_dashboards_workdir }}/opensearch_dashboards.yml:/usr/share/opensearch-dashboards/config/opensearch_dashboards.yml"
     ports:
       - "{{ network.bind_host }}:5601:5601"
+    log_driver: json-file
+    log_options:
+      max-size: "{{ docker_log_max_size }}"
   when: "'all_in_one' in groups and inventory_hostname in groups['all_in_one']"

--- a/ansible/roles/redis/defaults/main.yml
+++ b/ansible/roles/redis/defaults/main.yml
@@ -13,3 +13,4 @@ network:
   publish_host: "{{ ansible_default_ipv4.address }}"
 
 docker_network_name: bap_network
+docker_log_max_size: 500m

--- a/ansible/roles/redis/tasks/main.yml
+++ b/ansible/roles/redis/tasks/main.yml
@@ -43,5 +43,8 @@
       - redis_data:/bitnami/redis/data
       - "{{ redis_workdir }}/overrides.conf:/opt/bitnami/redis/mounted-etc/overrides.conf"
       - "{{ redis_log_dir }}:/opt/bitnami/redis/logs/"
+    log_driver: json-file
+    log_options:
+      max-size: "{{ docker_log_max_size }}"
     ports:
       - "{{ network.bind_host }}:6379:6379"

--- a/ansible/roles/sortinghat/defaults/main.yml
+++ b/ansible/roles/sortinghat/defaults/main.yml
@@ -89,3 +89,4 @@ certs_dir: "{{ nginx_workdir }}/certs"
 #   key: foo/cert.key
 
 docker_network_name: bap_network
+docker_log_max_size: 500m

--- a/ansible/roles/sortinghat/tasks/main.yml
+++ b/ansible/roles/sortinghat/tasks/main.yml
@@ -222,6 +222,9 @@
       - "{{ sortinghat_multi_tenant_list_path }}:{{ sortinghat_multi_tenant_list_path }}"
     ports:
       - "{{ network.bind_host }}:9314:9314"
+    log_driver: json-file
+    log_options:
+      max-size: "{{ docker_log_max_size }}"
 
 - name: "Add {{ sortinghat_superuser_name }} user to all tenants for {{ ansible_hostname }}"
   command: >

--- a/ansible/roles/sortinghat/tasks/nginx.yml
+++ b/ansible/roles/sortinghat/tasks/nginx.yml
@@ -23,6 +23,9 @@
       - "80:80"    
     exposed_ports:
       - "80"
+    log_driver: json-file
+    log_options:
+      max-size: "{{ docker_log_max_size }}"
   when: enable_ssl|bool == false
 
 - name: Start NGINX container enabling SSL
@@ -39,4 +42,7 @@
     exposed_ports:
       - "80"
       - "443"
+    log_driver: json-file
+    log_options:
+      max-size: "{{ docker_log_max_size }}"
   when: enable_ssl|bool == true

--- a/ansible/roles/sortinghat_worker/defaults/main.yml
+++ b/ansible/roles/sortinghat_worker/defaults/main.yml
@@ -48,3 +48,4 @@ sortinghat_multi_tenant: "true"
 sortinghat_multi_tenant_list_path: "{{ sortinghat_worker_workdir }}/sortinghat_multi_tenant_list_path.json"
 
 docker_network_name: bap_network
+docker_log_max_size: 500m

--- a/ansible/roles/sortinghat_worker/tasks/main.yml
+++ b/ansible/roles/sortinghat_worker/tasks/main.yml
@@ -145,6 +145,9 @@
       SORTINGHAT_MULTI_TENANT_LIST_PATH: "{{ sortinghat_multi_tenant_list_path }}"
     volumes:
       - "{{ sortinghat_multi_tenant_list_path }}:{{ sortinghat_multi_tenant_list_path }}"
+    log_driver: json-file
+    log_options:
+      max-size: "{{ docker_log_max_size }}"
   with_sequence: start=1 end="{{ sortinghat_workers }}"
 
 - name: "Remove old SortingHat dedicated workers {{ item.tenant }}"
@@ -184,6 +187,9 @@
       SORTINGHAT_MULTI_TENANT_LIST_PATH: "{{ sortinghat_multi_tenant_list_path }}"
     volumes:
       - "{{ sortinghat_multi_tenant_list_path }}:{{ sortinghat_multi_tenant_list_path }}"
+    log_driver: json-file
+    log_options:
+      max-size: "{{ docker_log_max_size }}"
   loop: "{{ tenants }}"
   when:
     - sortinghat_multi_tenant is defined


### PR DESCRIPTION
This commit adds a docker container log size limit (stored at `/var/lib/docker/containers/<container-ID>/<container-ID>-json.log`) to prevent the disk from filling up.