### PR TITLE
[nginx] Allow deploying Mordred without a virtual host

### DIFF
--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -63,7 +63,7 @@
   loop: "{{ instances }}"
   loop_control:
     loop_var: instance
-  when: custom_cert is undefined
+  when: custom_cert is undefined and instance.nginx is defined
 
 - name: "Create a docker network: {{ docker_network_name }}"
   docker_network:

--- a/ansible/roles/nginx/tasks/virtualhost.yml
+++ b/ansible/roles/nginx/tasks/virtualhost.yml
@@ -4,7 +4,7 @@
   include_tasks: certbot.yml
   vars:
     hostname: "{{ instance.nginx.fqdn }}"
-  when: custom_cert is undefined
+  when: custom_cert is undefined and instance.nginx is defined
 
 - name: "Copy custom SSL certificates"
   run_once: true
@@ -42,3 +42,4 @@
     src: vhost.j2
     dest: "{{ nginx_virtualhosts_workdir }}/{{ instance.nginx.fqdn }}.conf"
     backup: true
+  when: instance.nginx is defined


### PR DESCRIPTION
All instance configurations require an `nginx.fqdn`, but with this change, it is optional. Thus, it is possible to deploy a Mordred without a virtual host.