### PR TITLE
[nginx] Update ssl_ciphers list

### DIFF
--- a/ansible/roles/nginx/templates/vhost.j2
+++ b/ansible/roles/nginx/templates/vhost.j2
@@ -19,8 +19,9 @@ server {
     ssl_certificate_key /etc/ssl/certbot_certs/live/{{ instance.nginx.fqdn }}/privkey.pem;
 {% endif %}
     ssl_protocols TLSv1.3 TLSv1.2;
-    ssl_ciphers AES256+EECDH:AES256+EDH:!aNULL;
-    ssl_prefer_server_ciphers on;
+    ssl_ecdh_curve X25519:prime256v1:secp384r1;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305:TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256;
+    ssl_prefer_server_ciphers off;
     ssl_stapling on;
     ssl_stapling_verify on;
     ssl_session_cache shared:SSL:10m;


### PR DESCRIPTION
Mozilla uses this list, and it avoids two weak algorithms
- ECDHE-ECDSA-AES256-SHA384 (TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA)
- ECDHE-ECDSA-AES256-GCM-SHA384 (TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384)

https://wiki.mozilla.org/Security/Server_Side_TLS