### PR TITLE
[mordred] Fix opensearch_host

### DIFF
--- a/ansible/roles/mordred/defaults/main.yml
+++ b/ansible/roles/mordred/defaults/main.yml
@@ -35,7 +35,7 @@ mordred_aliases_url: https://raw.githubusercontent.com/chaoss/grimoirelab-sirmor
 ##     sources_repository: "<PROJECT2_SOURCE_REPO_URL>"
 ##     host: 1
 mariadb_hosts: "{{ groups['all_in_one'][0] | default(groups['mariadb'][0]) }}"
-opensearch_host: "{{ groups['all_in_one'][0] | default(groups['opensearch'][0]) }}"
+opensearch_host: "{{ groups['all_in_one'][0] | default(groups['opensearch_manager'][0]) }}"
 
 docker_network_name: bap_network
 docker_log_max_size: 500m


### PR DESCRIPTION
OpenSearch cluster has two types (manager and data) and configure 'opensearch_host' as manager node.