### PR TITLE
[sortinghat] Fix allowed host

### DIFF
--- a/ansible/roles/sortinghat/tasks/main.yml
+++ b/ansible/roles/sortinghat/tasks/main.yml
@@ -148,8 +148,10 @@
     allowed_hosts: |-
       [
       {% for item in instances %}
-        {{ "" if loop.first else "," }}
-        "{{ item.nginx.fqdn | regex_findall('[a-zA-Z0-9-]*(?P<domain>\..*)', '\\g<domain>') | first }}"
+        {% if item.nginx is defined %}
+          {{ "" if loop.first else "," }}
+          "{{ item.nginx.fqdn | regex_findall('[a-zA-Z0-9-]*(?P<domain>\..*)', '\\g<domain>') | first }}"
+        {% endif %}
       {% endfor %}
       ]
 


### PR DESCRIPTION
Only add Nginx fqdn to the sortinghat 'allowed_host' when nginx is defined in the instance.