### PR TITLE
[nginx] Disable version

### DIFF
--- a/ansible/roles/nginx/templates/vhost.j2
+++ b/ansible/roles/nginx/templates/vhost.j2
@@ -4,6 +4,9 @@ server {
     include    mime.types;
     sendfile   on;
 
+    # Disable nginx version
+    server_tokens off;
+
     listen 443 ssl;
     http2 on;
     server_name {{ instance.nginx.fqdn }};


### PR DESCRIPTION
Disables emitting nginx version on error pages and in the “Server” response header field.