### PR TITLE
Nginx certbot alert

### DIFF
--- a/ansible/roles/monitoring/defaults/main.yml
+++ b/ansible/roles/monitoring/defaults/main.yml
@@ -20,6 +20,7 @@ opensearch_logging_include_paths: [
 nginx_logging_access_include_paths: ["/docker/nginx/log/access.log"]
 nginx_logging_error_include_paths: ["/docker/nginx/log/error.log"]
 nginx_metric_stub_status_url: "http://{{ hostvars[groups['nginx'][0]]['ansible_default_ipv4']['address'] }}:80/nginx_status"
+nginx_logging_certbot_renew_include_paths: ["/docker/nginx/letsencrypt/logs/certbot_renew.log"]
 
 # Redis
 redis_logging_include_paths: ["/docker/redis/log/redis.log"]

--- a/ansible/roles/monitoring/templates/nginx_ops_agent.yaml.j2
+++ b/ansible/roles/monitoring/templates/nginx_ops_agent.yaml.j2
@@ -6,12 +6,24 @@ logging:
     nginx_error:
       type: nginx_error
       include_paths: {{ nginx_logging_error_include_paths }}
+    certbot_renew:
+      type: files
+      include_paths: {{ nginx_logging_certbot_renew_include_paths }}
+  processors:
+    certbot_parser:
+      type: parse_regex
+      regex: "^(?<time>[\d-]* [\d:]*) - (?<level>[^ ]*) - (?<message>[^ :].*)$"
   service:
     pipelines:
       nginx:
         receivers:
           - nginx_access
           - nginx_error
+      certbot:
+        receivers:
+          - certbot_renew
+        processors:
+          - certbot_parser
 metrics:
   receivers:
     nginx:

--- a/ansible/roles/nginx/files/logrotate.conf
+++ b/ansible/roles/nginx/files/logrotate.conf
@@ -1,0 +1,23 @@
+# see "man logrotate" for details
+
+# global options do not affect preceding include directives
+
+# rotate log files weekly
+weekly
+
+# keep 4 weeks worth of backlogs
+rotate 4
+
+# create new (empty) log files after rotating old ones
+create
+
+# use date as a suffix of the rotated file
+#dateext
+
+# uncomment this if you want your log files compressed
+#compress
+
+# packages drop log rotation information into this directory
+include /etc/logrotate.d
+
+# system-specific logs may also be configured here.

--- a/ansible/roles/nginx/tasks/certbot.yml
+++ b/ansible/roles/nginx/tasks/certbot.yml
@@ -40,6 +40,6 @@
   run_once: true
   cron:
     name: Certbot renewal
-    job: "{{ nginx_letsencrypt_certbot_renew_script_dest }}"
+    job: "sudo {{ nginx_letsencrypt_certbot_renew_script_dest }}"
     user: root
     special_time: "{{ nginx_letsencrypt_cronjob_time }}"

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -1,5 +1,22 @@
 ---
 
+- name: Install logrotate
+  package:
+    name: logrotate
+    state: present
+
+- name: Copy logrotate.conf to /etc/logrotate.conf
+  copy:
+    src: "{{ role_path }}/files/logrotate.conf"
+    dest: /etc/logrotate.conf
+    mode: "0644"
+
+- name: Generate /etc/logrotate.d/nginx
+  template:
+    src: nginx_logrotate.j2
+    dest: /etc/logrotate.d/nginx
+    mode: "0644"
+
 - name: Remove old NGINX container
   docker_container:
     name: "{{ nginx_docker_container }}"

--- a/ansible/roles/nginx/templates/certbot_renew.sh.j2
+++ b/ansible/roles/nginx/templates/certbot_renew.sh.j2
@@ -9,12 +9,13 @@ CERTBOT_OUTPUT="{{ nginx_letsencrypt_logsdir }}/certbot_renew.log"
 WARNING_DAYS="{{ nginx_letsencrypt_cert_warning_days }}"
 
 DATE_NOW=$(date +"%Y-%m-%d %H:%M:%S")
+RESTART=FALSE
 
 # Function to check certs
 renew_cert() {
     cert_path="$CERTBOT_CERTS_DIR/$1/cert.pem"
     if [ ! -f "$cert_path" ]; then
-        echo "$DATE_NOW - $1: 'cert.pem' not found at $CERTBOT_CERTS_DIR/$1/" >> "$CERTBOT_OUTPUT"
+        echo "$DATE_NOW - ERROR - $1: 'cert.pem' not found at $CERTBOT_CERTS_DIR/$1/" >> "$CERTBOT_OUTPUT"
         return 1
     fi
 
@@ -23,16 +24,16 @@ renew_cert() {
     days_left=$(((`date -d "$expiry_date" +%s`-`date -d "now" +%s`)/(60*60*24)))
 
     if [ "$days_left" -lt "$WARNING_DAYS" ]; then
-        echo "$DATE_NOW - $1: Expires in $days_left days. Renewing cert" >> $CERTBOT_OUTPUT
+        echo "$DATE_NOW - WARNING - $1: Expires in $days_left days. Renewing cert" >> $CERTBOT_OUTPUT
         certbot -q renew --work-dir $CERTBOT_WORK_DIR --logs-dir $CERTBOT_LOGS_DIR --config-dir $CERTBOT_CONFIG_DIR
         if [ $? -eq 0 ]; then
-            echo "$DATE_NOW - $1: Cert renewed" >> $CERTBOT_OUTPUT
-            docker restart "{{ nginx_docker_container }}"
+            echo "$DATE_NOW - INFO - $1: Cert renewed" >> $CERTBOT_OUTPUT
         else
-            echo "$DATE_NOW - $1: ERROR cert not renewed" >> $CERTBOT_OUTPUT
+            echo "$DATE_NOW - ERROR - $1: Cert not renewed" >> $CERTBOT_OUTPUT
         fi
+        RESTART=TRUE
     else
-        echo "$DATE_NOW - $1: Still valid. It expires on $expiry_date" >> $CERTBOT_OUTPUT
+        echo "$DATE_NOW - INFO - $1: Still valid. It expires on $expiry_date" >> $CERTBOT_OUTPUT
     fi
 }
 
@@ -42,3 +43,8 @@ for cert_dir in "$CERTBOT_CERTS_DIR"/*; do
         renew_cert "$domain"
     fi
 done
+
+if [ "$RESTART" == TRUE ]; then
+    echo "$DATE_NOW - INFO - Docker: Restarting NGINX container" >> $CERTBOT_OUTPUT
+    docker restart "{{ nginx_docker_container }}"
+fi

--- a/ansible/roles/nginx/templates/nginx_logrotate.j2
+++ b/ansible/roles/nginx/templates/nginx_logrotate.j2
@@ -1,0 +1,13 @@
+{{ nginx_log_dir }}/*.log
+{{ nginx_letsencrypt_logsdir }}/*.log
+{
+    su root root
+    rotate 14
+    size 5M
+    missingok
+    notifempty
+    delaycompress
+    compress
+    create 0640
+    copytruncate
+}


### PR DESCRIPTION
Create a new metric and alert for Nginx to check if Certbot successfully renewed the certificates.

Improves the `certbot_renew.sh` script and the output to make it more suitable for GCP Logging to consume. The Nginx container will only restart once all certificates have been checked and if any have been renewed. Also, add logrotate to the logs:
- `{{ nginx_log_dir }}/*.log`
- `{{ nginx_letsencrypt_logsdir }}/*.log`


Fixes #132