### PR TITLE
[ansible] Disable logging for tasks with a secret

### DIFF
--- a/ansible/roles/mariadb/tasks/main.yml
+++ b/ansible/roles/mariadb/tasks/main.yml
@@ -128,6 +128,7 @@
     owner: '1000'
     group: '1000'
     mode: 0644
+  no_log: true
 
 - name: Create cron job
   cron:

--- a/ansible/roles/mordred/tasks/main.yml
+++ b/ansible/roles/mordred/tasks/main.yml
@@ -28,6 +28,7 @@
     - "{{ instances }}"
   delegate_to: "{{ groups['all_in_one'][0] | default(groups['mordred'][item.mordred.host]) }}"
   run_once: true
+  no_log: true
 
 - name: docker
   docker_container:
@@ -51,3 +52,4 @@
     - "{{ instances }}"
   delegate_to: "{{ groups['all_in_one'][0] | default(groups['mordred'][item.mordred.host]) }}"
   run_once: true
+  no_log: true

--- a/ansible/roles/nginx/tasks/gcs.yml
+++ b/ansible/roles/nginx/tasks/gcs.yml
@@ -34,6 +34,7 @@
     owner: '1000'
     group: '1000'
     mode: 0644
+  no_log: true
 
 - name: Activate service account
   shell: gcloud auth activate-service-account --key-file "{{ nginx_keys_workdir }}/key.json"

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -64,6 +64,7 @@
   loop_control:
     loop_var: instance
   when: custom_cert is undefined and instance.nginx is defined
+  no_log: true
 
 - name: "Configure virtualhost (certbot with acme-challenge) for default host"
   template:
@@ -71,6 +72,7 @@
     dest: "{{ nginx_virtualhosts_workdir }}/default.conf"
     backup: true
   when: custom_cert is undefined and nginx_default_host is defined
+  no_log: true
 
 - name: "Create a docker network: {{ docker_network_name }}"
   docker_network:
@@ -98,6 +100,7 @@
   loop: "{{ instances }}"
   loop_control:
     loop_var: instance
+  no_log: true
 
 - name: Copy the default host configuration files
   copy:

--- a/ansible/roles/nginx/tasks/virtualhost.yml
+++ b/ansible/roles/nginx/tasks/virtualhost.yml
@@ -28,6 +28,7 @@
   loop_control:
     label: "{{ item.dest }}"
   when: custom_cert is defined
+  no_log: true
 
 - name: "Create load balancer configuration for OpenSearch nodes"
   run_once: true

--- a/ansible/roles/nginx/tasks/virtualhost_default.yml
+++ b/ansible/roles/nginx/tasks/virtualhost_default.yml
@@ -39,6 +39,7 @@
   loop_control:
     label: "{{ item.dest }}"
   when: custom_cert is defined
+  no_log: true
 
 - name: "Create virtualhost configuration for default.conf"
   template:

--- a/ansible/roles/opensearch/tasks/certificates.yml
+++ b/ansible/roles/opensearch/tasks/certificates.yml
@@ -24,3 +24,4 @@
     group: '1000'
     mode: 0600
   loop: "{{ certs_files.values() | list }}"
+  no_log: true

--- a/ansible/roles/opensearch/tasks/security_config.yml
+++ b/ansible/roles/opensearch/tasks/security_config.yml
@@ -28,6 +28,7 @@
   loop_control:
     label: "{{ item.hash_name }}"
   when: not security_initialized_mark.stat.exists
+  no_log: true
 
 - name: Copy security configuration, internal users and roles mappings
   template:
@@ -43,3 +44,4 @@
     - path: opensearch-security/roles_mapping.yml
   when: item.always_update is defined or
         not security_initialized_mark.stat.exists
+  no_log: true

--- a/ansible/roles/opensearch/tasks/snapshots.yml
+++ b/ansible/roles/opensearch/tasks/snapshots.yml
@@ -22,6 +22,7 @@
     owner: '1000'
     group: '1000'
     mode: 0644
+  no_log: true
 
 - name: Copy credentials file to OpenSearch manager container
   command: docker cp {{ gcp_service_account_file }} {{ opensearch_docker_container }}:{{ gcs_cred_file_container }}

--- a/ansible/roles/sortinghat/tasks/main.yml
+++ b/ansible/roles/sortinghat/tasks/main.yml
@@ -120,6 +120,7 @@
     src: "{{ gcp_service_account_host_file }}"
     dest: "{{ gcp_service_account_file }}"
     mode: 0644
+  no_log: true
 
 - name: "Create SortingHat multi tenant file"
   copy:

--- a/ansible/roles/sortinghat/tasks/virtualhost.yml
+++ b/ansible/roles/sortinghat/tasks/virtualhost.yml
@@ -45,6 +45,7 @@
   loop_control:
     label: "{{ item.dest }}"
   when: (enable_ssl|bool == true) and (certs_dir is defined)
+  no_log: true
 
 - name: "Create virtualhost configuration for {{ ansible_hostname }}"
   template:

--- a/ansible/roles/sortinghat_worker/tasks/main.yml
+++ b/ansible/roles/sortinghat_worker/tasks/main.yml
@@ -165,6 +165,7 @@
     - sortinghat_multi_tenant == "true"
     - item.dedicated_queue is defined
     - item.dedicated_queue == true
+  no_log: true
 
 - name: "Start SortingHat dedicated worker {{ item.tenant }}"
   docker_container:
@@ -203,3 +204,4 @@
     - sortinghat_multi_tenant == "true"
     - item.dedicated_queue is defined
     - item.dedicated_queue == true
+  no_log: true


### PR DESCRIPTION
This commit disables logging of tasks with any secrets by adding `no_log: true` to that task.