### PR TITLE
[ansible/opensearch] Add index templates and policy

### DIFF
--- a/ansible/roles/opensearch/defaults/main.yml
+++ b/ansible/roles/opensearch/defaults/main.yml
@@ -27,7 +27,11 @@ do_not_fail_on_forbidden: false
 anonymous_auth_enabled: false
 opensearch_endpoint: "https://{{ network.publish_host }}:9200"
 number_of_shards: "{{ groups['opensearch_data'] | length }}"
-auto_expand_replicas: "0-1"
+number_of_replicas: 1
+auditlog_policy:
+  name: "auditlog_policy"
+  description: "3 month retention policy for auditlog indexes."
+  min_index_age: "90d"
 
 # Certificates files and their DNs
 certs_dir: "{{ opensearch_workdir }}/certs"

--- a/ansible/roles/opensearch/tasks/index_templates_policy.yml
+++ b/ansible/roles/opensearch/tasks/index_templates_policy.yml
@@ -1,0 +1,100 @@
+- name: Set default template for indices
+  uri:
+    url: "{{ opensearch_endpoint }}/_template/default"
+    method: PUT
+    status_code: 200
+    client_cert: "{{ certs_dir }}/{{ certs_files.admin_cert }}"
+    client_key: "{{ certs_dir }}/{{ certs_files.admin_key }}"
+    body_format: json
+    body:
+      template: "*"
+      order: -1
+      settings:
+        number_of_shards: "{{ number_of_shards }}"
+        number_of_replicas: "{{ number_of_replicas }}"
+    validate_certs: false
+
+- name: Check if auditlog policy exists
+  uri:
+    url: "{{ opensearch_endpoint }}/_plugins/_ism/policies/{{ auditlog_policy.name }}"
+    method: GET
+    status_code: [200, 404]
+    client_cert: "{{ certs_dir }}/{{ certs_files.admin_cert }}"
+    client_key: "{{ certs_dir }}/{{ certs_files.admin_key }}"
+    validate_certs: false
+  register: auditlog_policy_result
+
+- name: Set auditlog policy
+  uri:
+    url: "{{ opensearch_endpoint }}/_plugins/_ism/policies/{{ auditlog_policy.name }}"
+    method: PUT
+    status_code: 201
+    client_cert: "{{ certs_dir }}/{{ certs_files.admin_cert }}"
+    client_key: "{{ certs_dir }}/{{ certs_files.admin_key }}"
+    body_format: json
+    body:
+      policy:
+        description: "{{ auditlog_policy.description }}"
+        default_state: "hot"
+        states:
+          - name: "hot"
+            actions: []
+            transitions:
+              - state_name: "delete"
+                conditions:
+                  min_index_age: "{{ auditlog_policy.min_index_age }}"
+          - name: "delete"
+            actions:
+              - delete: {}
+            transitions: []
+    validate_certs: false
+  when: auditlog_policy_result.status == 404
+
+- name: Update auditlog policy
+  uri:
+    url: "{{ opensearch_endpoint }}/_plugins/_ism/policies/{{ auditlog_policy.name }}?if_seq_no={{ auditlog_policy_result.json._seq_no }}&if_primary_term={{ auditlog_policy_result.json._primary_term }}"
+    method: PUT
+    status_code: 200
+    client_cert: "{{ certs_dir }}/{{ certs_files.admin_cert }}"
+    client_key: "{{ certs_dir }}/{{ certs_files.admin_key }}"
+    body_format: json
+    body:
+      policy:
+        description: "{{ auditlog_policy.description }}"
+        default_state: "hot"
+        states:
+          - name: "hot"
+            actions: []
+            transitions:
+              - state_name: "delete"
+                conditions:
+                  min_index_age: "{{ auditlog_policy.min_index_age }}"
+          - name: "delete"
+            actions:
+              - delete: {}
+            transitions: []
+    validate_certs: false
+  when: auditlog_policy_result.status == 200
+
+- name: Set auditlog indexes template
+  uri:
+    url: "{{ opensearch_endpoint }}/_index_template/auditlog_template"
+    method: PUT
+    status_code: 200
+    client_cert: "{{ certs_dir }}/{{ certs_files.admin_cert }}"
+    client_key: "{{ certs_dir }}/{{ certs_files.admin_key }}"
+    body_format: json
+    body:
+      index_patterns:
+        - "security-auditlog-*"
+      template:
+        settings:
+          index:
+            number_of_shards: "{{ number_of_shards }}"
+            number_of_replicas: "{{ number_of_replicas }}"
+            codec: "best_compression"
+            refresh_interval: "30s"
+            plugins:
+              index_state_management:
+                policy_id: "{{ auditlog_policy.name }}"
+    validate_certs: false

--- a/ansible/roles/opensearch/tasks/main.yml
+++ b/ansible/roles/opensearch/tasks/main.yml
@@ -73,26 +73,9 @@
   import_tasks: security_backup.yml
   when: "'opensearch-manager' in inventory_hostname or 'all_in_one' in groups"
 
-- name: Set default template for indices
-  uri:
-    url: "{{ opensearch_endpoint }}/_template/default"
-    method: PUT
-    status_code: 200
-    client_cert: "{{ certs_dir }}/{{ certs_files.admin_cert }}"
-    client_key: "{{ certs_dir }}/{{ certs_files.admin_key }}"
-    body_format: json
-    body:
-      template: "*"
-      order: -1
-      settings:
-        number_of_shards: "{{ number_of_shards }}"
-        auto_expand_replicas: "{{ auto_expand_replicas }}"
-    validate_certs: false
-  register: result
-  until: result.status == 200
-  retries: 10
-  delay: 2
-  run_once: true
+- name: Configure OpenSearch indexes templates and policy
+  import_tasks: index_templates_policy.yml
+  when: "'opensearch-manager' in inventory_hostname or 'all_in_one' in groups"
 
 - name: Wait for OpenSearch container(s) to be available
   uri:

--- a/docs/deployment_and_config.md
+++ b/docs/deployment_and_config.md
@@ -270,6 +270,10 @@ Replace the entries in `<>` with your values:
 - `opensearch_customer_password`: strong password for the default user.
 - `opensearch_readall_password`: strong password for the internal OpenSearch user.
 - `opensearch_backups_password`: strong password for the backups user.
+- `auditlog_policy`: auditlog policy.
+- `auditlog_policy.name`: name of the auditlog policy (by default is `auditlog_policy`).
+- `auditlog_policy.description`: description of the auditlog policy (by default is `3 month retention policy for auditlog indexes.`).
+- `auditlog_policy.min_index_age`: minimum age of the index to be eligible for rollover (by default is `90d`).
 - `backups_assets_bucket`: this is the name of the bucket created by Terraform
   for storing the OpenSearch snapshots and MariaDB backups.
   Check your cloud provider to obtain the name of the bucket. If you didn't


### PR DESCRIPTION
- Update the default template: `number_of_replicas` instead of `auto_expand_replicas`.
- Add auditlog index template: only for indexes starting with `security-auditlog-`.
- Add auditlog policy: 3 month retention.
- Add cluster health monitor (Optional): Notify by Slack when the cluster is not green.

docs/deployment_and_config.md: updated accordingly.