### PR TITLE
[terraform] Update hashicorp/google version to 7.0

### DIFF
--- a/docs/provision.md
+++ b/docs/provision.md
@@ -83,7 +83,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 7.0"
     }
   }
 }

--- a/terraform/modules/bap_alerting_gcp/main.tf
+++ b/terraform/modules/bap_alerting_gcp/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 7.0"
     }
   }
 }

--- a/terraform/modules/bap_env_gcp/main.tf
+++ b/terraform/modules/bap_env_gcp/main.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 7.0"
     }
   }
 }

--- a/terraform/modules/bap_gcp_instance/main.tf
+++ b/terraform/modules/bap_gcp_instance/main.tf
@@ -4,6 +4,7 @@ terraform {
   required_providers {
       google = {
         source = "hashicorp/google"
+        version = "~> 7.0"
       }
       ansible = {
         source  = "nbering/ansible"


### PR DESCRIPTION
This commit updates the `hashicorp/google` version from `~> 4.0` to `~> 7.0`.

docs/provision.md updated accordingly.