### PR TITLE
[terraform] Add OpenSearch cluster status alerts

### DIFF
--- a/terraform/modules/bap_alerting_gcp/opensearch.tf
+++ b/terraform/modules/bap_alerting_gcp/opensearch.tf
@@ -42,3 +42,141 @@ resource "google_monitoring_alert_policy" "opensearch_absent_metrics" {
 
   notification_channels = var.notification_channels
 }
+
+# OpenSearch cluster health status metrics and alerts
+resource "google_logging_metric" "opensearch_cluster_health_green_metric" {
+  name        = "opensearch.cluster.health_green"
+  description = "The OpenSearch cluster is healthy (green status)"
+  count         = var.alerts ? 1 : 0
+  filter      = "\"Cluster health status changed from\" AND \"to [GREEN]\""
+}
+
+resource "google_logging_metric" "opensearch_cluster_health_yellow_metric" {
+  name        = "opensearch.cluster.health_yellow"
+  description = "The OpenSearch cluster is not healthy (yellow status)"
+  count         = var.alerts ? 1 : 0
+  filter      = "\"Cluster health status changed from\" AND \"to [YELLOW]\""
+}
+
+resource "google_logging_metric" "opensearch_cluster_health_red_metric" {
+  name        = "opensearch.cluster.health_red"
+  description = "The OpenSearch cluster is not healthy (red status)"
+  count         = var.alerts ? 1 : 0
+  filter      = "\"Cluster health status changed from\" AND \"to [RED]\""
+}
+
+resource "google_monitoring_alert_policy" "opensearch_cluster_health_green_alert" {
+  project      = var.project
+
+  display_name = "OpenSearch - Cluster Health Green"
+  count        = var.alerts ? 1 : 0
+
+  documentation {
+    content   = "The OpenSearch cluster is healthy (green status)."
+    mime_type = "text/markdown"
+  }
+
+  combiner = "OR"
+  conditions {
+    display_name = "OpenSearch - Cluster Health Green"
+
+    condition_threshold {
+      filter = "resource.type = \"gce_instance\" AND metric.type = \"logging.googleapis.com/user/${google_logging_metric.opensearch_cluster_health_green_metric[count.index].name}\""
+      duration           = "0s"
+      comparison         = "COMPARISON_GT"
+      threshold_value    = 0
+      aggregations {
+        alignment_period     = "60s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_NONE"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+  alert_strategy {
+    notification_prompts = ["OPENED"]
+  }
+
+  notification_channels = var.notification_channels
+}
+
+resource "google_monitoring_alert_policy" "opensearch_cluster_health_yellow_alert" {
+  project      = var.project
+
+  display_name = "OpenSearch - Cluster Health Yellow"
+  count        = var.alerts ? 1 : 0
+
+  documentation {
+    content   = "The OpenSearch cluster is not healthy (yellow status): Some replica shards are not assigned."
+    mime_type = "text/markdown"
+  }
+
+  combiner = "OR"
+  severity = "WARNING"
+  conditions {
+    display_name = "OpenSearch - Cluster Health Yellow"
+
+    condition_threshold {
+      filter = "resource.type = \"gce_instance\" AND metric.type = \"logging.googleapis.com/user/${google_logging_metric.opensearch_cluster_health_yellow_metric[count.index].name}\""
+      duration           = "0s"
+      comparison         = "COMPARISON_GT"
+      threshold_value    = 0
+      aggregations {
+        alignment_period     = "60s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_NONE"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+  alert_strategy {
+    notification_prompts = ["OPENED"]
+  }
+
+  notification_channels = var.notification_channels
+}
+
+resource "google_monitoring_alert_policy" "opensearch_cluster_health_red_alert" {
+  project      = var.project
+
+  display_name = "OpenSearch - Cluster Health Red"
+  count        = var.alerts ? 1 : 0
+
+  documentation {
+    content   = "The OpenSearch cluster is not healthy (red status): Some primary shards are unassigned."
+    mime_type = "text/markdown"
+  }
+
+  combiner = "OR"
+  severity = "CRITICAL"
+  conditions {
+    display_name = "OpenSearch - Cluster Health Red"
+
+    condition_threshold {
+      filter = "resource.type = \"gce_instance\" AND metric.type = \"logging.googleapis.com/user/${google_logging_metric.opensearch_cluster_health_red_metric[count.index].name}\""
+      duration           = "0s"
+      comparison         = "COMPARISON_GT"
+      threshold_value    = 0
+      aggregations {
+        alignment_period     = "60s"
+        per_series_aligner   = "ALIGN_DELTA"
+        cross_series_reducer = "REDUCE_NONE"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+  alert_strategy {
+    notification_prompts = ["OPENED"]
+  }
+
+  notification_channels = var.notification_channels
+}


### PR DESCRIPTION
This commit creates three metrics and alerts in GCP. Alerts will be notified via Slack:

- Green: The cluster is healthy
- Yellow: Some replica shards are unassigned
- Red: Some primary shards are unassigned