### PR TITLE
Fix GCS access in all-in-one instance

### DIFF
--- a/ansible/roles/opensearch_dashboards/templates/opensearch_dashboards.yml.j2
+++ b/ansible/roles/opensearch_dashboards/templates/opensearch_dashboards.yml.j2
@@ -20,7 +20,7 @@ opensearch_security.readonly_mode.roles:
 # Anonymous user opendistro_security_anonymous
 {% if ('opensearch_dashboards_anonymous' in groups) and (inventory_hostname in groups['opensearch_dashboards_anonymous']) %}
 opensearch_security.auth.anonymous_auth_enabled: true
-{% elif 'all_in_one' in groups and instance[0].public %}
+{% elif 'all_in_one' in groups and instances[0].public %}
 opensearch_security.auth.anonymous_auth_enabled: true
 {% else %}
 opensearch_security.auth.anonymous_auth_enabled: false

--- a/opentofu/modules/bap_env_gcp/all_in_one.tf
+++ b/opentofu/modules/bap_env_gcp/all_in_one.tf
@@ -1,6 +1,9 @@
 module "all_in_one" {
   source = "../bap_gcp_instance"
 
+  service_account_email        = var.service_account_email
+  service_account_extra_scopes = ["cloud-platform"]
+
   prefix                  = var.prefix
   name                    = "all-in-one"
   node_count              = var.all_in_one_node_count


### PR DESCRIPTION
Configures the service account and adds `cloud-platform` scope to resolve permission errors during GCS bucket interaction.

Also, fix a typo in the OpenSearch Dashboards template.